### PR TITLE
Fix help to reference lw not liquidweb-cli

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var cfgFile string
 var lwCliInst instance.Client
 
 var rootCmd = &cobra.Command{
-	Use:   "liquidweb-cli",
+	Use:   "lw",
 	Short: "CLI interface for LiquidWeb",
 	Long: `CLI interface for LiquidWeb.
 


### PR DESCRIPTION
noticed help was still referencing liquidweb-cli as the binary. 