### PR TITLE
Dash consistency

### DIFF
--- a/cmd/cloudBackupDetails.go
+++ b/cmd/cloudBackupDetails.go
@@ -28,7 +28,7 @@ var cloudBackupDetailsCmd = &cobra.Command{
 	Short: "Get details of a Cloud Backup",
 	Long:  `Get details of a Cloud Backup`,
 	Run: func(cmd *cobra.Command, args []string) {
-		backupIdFlag, _ := cmd.Flags().GetInt64("backup_id")
+		backupIdFlag, _ := cmd.Flags().GetInt64("backup-id")
 
 		apiArgs := map[string]interface{}{"id": backupIdFlag}
 
@@ -45,7 +45,7 @@ var cloudBackupDetailsCmd = &cobra.Command{
 func init() {
 	cloudBackupCmd.AddCommand(cloudBackupDetailsCmd)
 
-	cloudBackupDetailsCmd.Flags().Int64("backup_id", -1,
+	cloudBackupDetailsCmd.Flags().Int64("backup-id", -1,
 		"id number of the backup (see 'cloud backup list')")
-	cloudBackupDetailsCmd.MarkFlagRequired("backup_id")
+	cloudBackupDetailsCmd.MarkFlagRequired("backup-id")
 }

--- a/cmd/cloudBackupDetails.go
+++ b/cmd/cloudBackupDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudBackupDetailsCmd = &cobra.Command{

--- a/cmd/cloudBackupList.go
+++ b/cmd/cloudBackupList.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -32,7 +32,7 @@ var cloudBackupListCmd = &cobra.Command{
 	Long:  `List Cloud Backups on your account`,
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag, _ := cmd.Flags().GetBool("json")
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		if uniqIdFlag != "" {
 			validateFields := map[interface{}]interface{}{
@@ -83,5 +83,5 @@ func init() {
 	cloudBackupCmd.AddCommand(cloudBackupListCmd)
 
 	cloudBackupListCmd.Flags().Bool("json", false, "output in json format")
-	cloudBackupListCmd.Flags().String("uniq_id", "", "only fetch backups made from this uniq_id")
+	cloudBackupListCmd.Flags().String("uniq-id", "", "only fetch backups made from this uniq-id")
 }

--- a/cmd/cloudBackupRestore.go
+++ b/cmd/cloudBackupRestore.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var cloudBackupRestoreCmd = &cobra.Command{
 	Short: "Restore a Cloud Backup on a Cloud Server",
 	Long:  `Restore a Cloud Backup on a Cloud Server.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		rebuildFsFlag, _ := cmd.Flags().GetBool("rebuild-fs")
 		backupIdFlag, _ := cmd.Flags().GetInt64("backup-id")
 
@@ -53,17 +53,17 @@ var cloudBackupRestoreCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Restoring backup! %+v\n", details)
-		fmt.Printf("\tcheck progress with 'cloud server status --uniq_id %s'\n", uniqIdFlag)
+		fmt.Printf("\tcheck progress with 'cloud server status --uniq-id %s'\n", uniqIdFlag)
 	},
 }
 
 func init() {
 	cloudBackupCmd.AddCommand(cloudBackupRestoreCmd)
 
-	cloudBackupRestoreCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
+	cloudBackupRestoreCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
 	cloudBackupRestoreCmd.Flags().Int64("backup-id", -1, "id of the Cloud Backup")
 	cloudBackupRestoreCmd.Flags().Bool("rebuild-fs", false, "rebuild filesystem before restoring")
 
-	cloudBackupRestoreCmd.MarkFlagRequired("uniq_id")
+	cloudBackupRestoreCmd.MarkFlagRequired("uniq-id")
 	cloudBackupRestoreCmd.MarkFlagRequired("backup-id")
 }

--- a/cmd/cloudBackupRestore.go
+++ b/cmd/cloudBackupRestore.go
@@ -31,7 +31,7 @@ var cloudBackupRestoreCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
 		rebuildFsFlag, _ := cmd.Flags().GetBool("rebuild-fs")
-		backupIdFlag, _ := cmd.Flags().GetInt64("backup_id")
+		backupIdFlag, _ := cmd.Flags().GetInt64("backup-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag:   "UniqId",
@@ -61,9 +61,9 @@ func init() {
 	cloudBackupCmd.AddCommand(cloudBackupRestoreCmd)
 
 	cloudBackupRestoreCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
-	cloudBackupRestoreCmd.Flags().Int64("backup_id", -1, "id of the Cloud Backup")
+	cloudBackupRestoreCmd.Flags().Int64("backup-id", -1, "id of the Cloud Backup")
 	cloudBackupRestoreCmd.Flags().Bool("rebuild-fs", false, "rebuild filesystem before restoring")
 
 	cloudBackupRestoreCmd.MarkFlagRequired("uniq_id")
-	cloudBackupRestoreCmd.MarkFlagRequired("backup_id")
+	cloudBackupRestoreCmd.MarkFlagRequired("backup-id")
 }

--- a/cmd/cloudImageCreate.go
+++ b/cmd/cloudImageCreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var cloudImageCreateCmd = &cobra.Command{
 	Short: "Create a Cloud Image",
 	Long:  `Create a Cloud Image.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		nameFlag, _ := cmd.Flags().GetString("name")
 
 		validateFields := map[interface{}]interface{}{
@@ -56,9 +56,9 @@ var cloudImageCreateCmd = &cobra.Command{
 func init() {
 	cloudImageCmd.AddCommand(cloudImageCreateCmd)
 
-	cloudImageCreateCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
+	cloudImageCreateCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
 	cloudImageCreateCmd.Flags().String("name", "", "name for the Cloud Image")
 
-	cloudImageCreateCmd.MarkFlagRequired("uniq_id")
+	cloudImageCreateCmd.MarkFlagRequired("uniq-id")
 	cloudImageCreateCmd.MarkFlagRequired("name")
 }

--- a/cmd/cloudImageDelete.go
+++ b/cmd/cloudImageDelete.go
@@ -29,7 +29,7 @@ var cloudImageDeleteCmd = &cobra.Command{
 	Short: "Delete a Cloud Image",
 	Long:  `Delete a Cloud Image`,
 	Run: func(cmd *cobra.Command, args []string) {
-		imageIdFlag, _ := cmd.Flags().GetInt64("image_id")
+		imageIdFlag, _ := cmd.Flags().GetInt64("image-id")
 		forceFlag, _ := cmd.Flags().GetBool("force")
 
 		// if force flag wasn't passed
@@ -55,8 +55,8 @@ var cloudImageDeleteCmd = &cobra.Command{
 func init() {
 	cloudImageCmd.AddCommand(cloudImageDeleteCmd)
 
-	cloudImageDeleteCmd.Flags().Int64("image_id", -1,
+	cloudImageDeleteCmd.Flags().Int64("image-id", -1,
 		"id number of the image (see 'cloud image list')")
 	cloudImageDeleteCmd.Flags().Bool("force", false, "bypass dialog confirmation")
-	cloudImageDeleteCmd.MarkFlagRequired("image_id")
+	cloudImageDeleteCmd.MarkFlagRequired("image-id")
 }

--- a/cmd/cloudImageDelete.go
+++ b/cmd/cloudImageDelete.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudImageDeleteCmd = &cobra.Command{

--- a/cmd/cloudImageDetails.go
+++ b/cmd/cloudImageDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudImageDetailsCmd = &cobra.Command{

--- a/cmd/cloudImageDetails.go
+++ b/cmd/cloudImageDetails.go
@@ -28,7 +28,7 @@ var cloudImageDetailsCmd = &cobra.Command{
 	Short: "Get details of a Cloud Image",
 	Long:  `Get details of a Cloud Image`,
 	Run: func(cmd *cobra.Command, args []string) {
-		imageIdFlag, _ := cmd.Flags().GetInt64("image_id")
+		imageIdFlag, _ := cmd.Flags().GetInt64("image-id")
 
 		apiArgs := map[string]interface{}{"id": imageIdFlag}
 
@@ -45,7 +45,7 @@ var cloudImageDetailsCmd = &cobra.Command{
 func init() {
 	cloudImageCmd.AddCommand(cloudImageDetailsCmd)
 
-	cloudImageDetailsCmd.Flags().Int64("image_id", -1,
+	cloudImageDetailsCmd.Flags().Int64("image-id", -1,
 		"id number of the image (see 'cloud image list')")
-	cloudImageDetailsCmd.MarkFlagRequired("image_id")
+	cloudImageDetailsCmd.MarkFlagRequired("image-id")
 }

--- a/cmd/cloudImageRename.go
+++ b/cmd/cloudImageRename.go
@@ -28,7 +28,7 @@ var cloudImageRenameCmd = &cobra.Command{
 	Short: "Renames a Cloud Image",
 	Long:  `Renames a Cloud Image.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		imageIdFlag, _ := cmd.Flags().GetInt64("image_id")
+		imageIdFlag, _ := cmd.Flags().GetInt64("image-id")
 		nameFlag, _ := cmd.Flags().GetString("name")
 
 		apiArgs := map[string]interface{}{"id": imageIdFlag, "name": nameFlag}
@@ -46,10 +46,10 @@ var cloudImageRenameCmd = &cobra.Command{
 func init() {
 	cloudImageCmd.AddCommand(cloudImageRenameCmd)
 
-	cloudImageRenameCmd.Flags().Int64("image_id", -1,
+	cloudImageRenameCmd.Flags().Int64("image-id", -1,
 		"id number of the image (see 'cloud image list')")
 	cloudImageRenameCmd.Flags().String("name", "", "new name for the Cloud Image")
 
-	cloudImageRenameCmd.MarkFlagRequired("image_id")
+	cloudImageRenameCmd.MarkFlagRequired("image-id")
 	cloudImageRenameCmd.MarkFlagRequired("name")
 }

--- a/cmd/cloudImageRename.go
+++ b/cmd/cloudImageRename.go
@@ -18,9 +18,8 @@ package cmd
 import (
 	"fmt"
 
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/spf13/cobra"
-
-	"github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudImageRenameCmd = &cobra.Command{

--- a/cmd/cloudImageRestore.go
+++ b/cmd/cloudImageRestore.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var cloudImageRestoreCmd = &cobra.Command{
 	Short: "Restore a Cloud Image on a Cloud Server",
 	Long:  `Restore a Cloud Image on a Cloud Server.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		rebuildFsFlag, _ := cmd.Flags().GetBool("rebuild-fs")
 		imageIdFlag, _ := cmd.Flags().GetInt64("image-id")
 
@@ -53,17 +53,17 @@ var cloudImageRestoreCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Restoring image! %+v\n", details)
-		fmt.Printf("\tcheck progress with 'cloud server status --uniq_id %s'\n", uniqIdFlag)
+		fmt.Printf("\tcheck progress with 'cloud server status --uniq-id %s'\n", uniqIdFlag)
 	},
 }
 
 func init() {
 	cloudImageCmd.AddCommand(cloudImageRestoreCmd)
 
-	cloudImageRestoreCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
+	cloudImageRestoreCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
 	cloudImageRestoreCmd.Flags().Int64("image-id", -1, "id of the Cloud Image")
 	cloudImageRestoreCmd.Flags().Bool("rebuild-fs", false, "rebuild filesystem before restoring")
 
-	cloudImageRestoreCmd.MarkFlagRequired("uniq_id")
+	cloudImageRestoreCmd.MarkFlagRequired("uniq-id")
 	cloudImageRestoreCmd.MarkFlagRequired("image-id")
 }

--- a/cmd/cloudImageRestore.go
+++ b/cmd/cloudImageRestore.go
@@ -31,7 +31,7 @@ var cloudImageRestoreCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
 		rebuildFsFlag, _ := cmd.Flags().GetBool("rebuild-fs")
-		imageIdFlag, _ := cmd.Flags().GetInt64("image_id")
+		imageIdFlag, _ := cmd.Flags().GetInt64("image-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag:  "UniqId",
@@ -61,9 +61,9 @@ func init() {
 	cloudImageCmd.AddCommand(cloudImageRestoreCmd)
 
 	cloudImageRestoreCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
-	cloudImageRestoreCmd.Flags().Int64("image_id", -1, "id of the Cloud Image")
+	cloudImageRestoreCmd.Flags().Int64("image-id", -1, "id of the Cloud Image")
 	cloudImageRestoreCmd.Flags().Bool("rebuild-fs", false, "rebuild filesystem before restoring")
 
 	cloudImageRestoreCmd.MarkFlagRequired("uniq_id")
-	cloudImageRestoreCmd.MarkFlagRequired("image_id")
+	cloudImageRestoreCmd.MarkFlagRequired("image-id")
 }

--- a/cmd/cloudNetworkPrivateAttach.go
+++ b/cmd/cloudNetworkPrivateAttach.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -39,7 +39,7 @@ Applications that communicate internally will frequently use this for both secur
 and cost-savings.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -66,12 +66,12 @@ and cost-savings.
 		}
 
 		fmt.Printf("Attaching %s to private network\n", details.Attached)
-		fmt.Printf("\n\nYou can check progress with 'cloud server status --uniq_id %s'\n", uniqIdFlag)
+		fmt.Printf("\n\nYou can check progress with 'cloud server status --uniq-id %s'\n", uniqIdFlag)
 	},
 }
 
 func init() {
 	cloudNetworkPrivateCmd.AddCommand(cloudNetworkPrivateAttachCmd)
-	cloudNetworkPrivateAttachCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
-	cloudNetworkPrivateAttachCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkPrivateAttachCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
+	cloudNetworkPrivateAttachCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudNetworkPrivateDetach.go
+++ b/cmd/cloudNetworkPrivateDetach.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -39,7 +39,7 @@ Applications that communicate internally will frequently use this for both secur
 and cost-savings.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -66,12 +66,12 @@ and cost-savings.
 		}
 
 		fmt.Printf("Detaching %s from private network\n", details.Detached)
-		fmt.Printf("\n\nYou can check progress with 'cloud server status --uniq_id %s'\n\n", uniqIdFlag)
+		fmt.Printf("\n\nYou can check progress with 'cloud server status --uniq-id %s'\n\n", uniqIdFlag)
 	},
 }
 
 func init() {
 	cloudNetworkPrivateCmd.AddCommand(cloudNetworkPrivateDetachCmd)
-	cloudNetworkPrivateDetachCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
-	cloudNetworkPrivateDetachCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkPrivateDetachCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
+	cloudNetworkPrivateDetachCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudNetworkPrivateDetails.go
+++ b/cmd/cloudNetworkPrivateDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -39,7 +39,7 @@ Applications that communicate internally will frequently use this for both secur
 and cost-savings.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -68,6 +68,6 @@ and cost-savings.
 
 func init() {
 	cloudNetworkPrivateCmd.AddCommand(cloudNetworkPrivateDetailsCmd)
-	cloudNetworkPrivateDetailsCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
-	cloudNetworkPrivateDetailsCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkPrivateDetailsCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
+	cloudNetworkPrivateDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudNetworkPublicAdd.go
+++ b/cmd/cloudNetworkPublicAdd.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -38,7 +38,7 @@ When the reboot flag is not passed, the IP will be assigned to the server, but i
 will be up to the administrator to configure the IP address(es) within the server.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		rebootFlag, _ := cmd.Flags().GetBool("reboot")
 		newIpsFlag, _ := cmd.Flags().GetInt64("new-ips")
 
@@ -93,12 +93,12 @@ will be up to the administrator to configure the IP address(es) within the serve
 
 func init() {
 	cloudNetworkPublicCmd.AddCommand(cloudNetworkPublicAddCmd)
-	cloudNetworkPublicAddCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
+	cloudNetworkPublicAddCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
 	cloudNetworkPublicAddCmd.Flags().Bool("reboot", false,
 		"wheter or not to automatically configure the new IP address(es) in the server (requires reboot)")
 	cloudNetworkPublicAddCmd.Flags().Int64("new-ips", 0, "amount of new ips to (randomly) grab")
 	cloudNetworkPublicAddCmd.Flags().StringSliceVar(&cloudNetworkPublicAddCmdPoolIpsFlag, "pool-ips", []string{},
 		"ips from your IP Pool separated by ',' to assign to the Cloud Server")
 
-	cloudNetworkPublicAddCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkPublicAddCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudNetworkPublicList.go
+++ b/cmd/cloudNetworkPublicList.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudNetworkPublicListCmdPoolIpsFlag []string
@@ -31,7 +31,7 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 	Short: "List a Cloud Servers Public IP(s)",
 	Long:  `List a Cloud Servers Public IP(s).`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		methodArgs := instance.AllPaginatedResultsArgs{
 			Method:         "bleed/network/ip/list",
@@ -61,6 +61,6 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 
 func init() {
 	cloudNetworkPublicCmd.AddCommand(cloudNetworkPublicListCmd)
-	cloudNetworkPublicListCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
-	cloudNetworkPublicListCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkPublicListCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
+	cloudNetworkPublicListCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudNetworkPublicRemove.go
+++ b/cmd/cloudNetworkPublicRemove.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -41,7 +41,7 @@ configuration.
 
 Note that you cannot remove the Cloud Servers primary ip with this command.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		rebootFlag, _ := cmd.Flags().GetBool("reboot")
 
 		validateFields := map[interface{}]interface{}{
@@ -79,12 +79,12 @@ Note that you cannot remove the Cloud Servers primary ip with this command.`,
 
 func init() {
 	cloudNetworkPublicCmd.AddCommand(cloudNetworkPublicRemoveCmd)
-	cloudNetworkPublicRemoveCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
+	cloudNetworkPublicRemoveCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
 	cloudNetworkPublicRemoveCmd.Flags().Bool("reboot", false,
 		"whether or not to automatically remove the IP address(es) in the server config (requires reboot)")
 	cloudNetworkPublicRemoveCmd.Flags().StringSliceVar(&cloudNetworkPublicRemoveCmdIpsFlag, "ips", []string{},
 		"ips separated by ',' to remove from the Cloud Server")
 
-	cloudNetworkPublicRemoveCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkPublicRemoveCmd.MarkFlagRequired("uniq-id")
 	cloudNetworkPublicRemoveCmd.MarkFlagRequired("ips")
 }

--- a/cmd/cloudNetworkVipCreate.go
+++ b/cmd/cloudNetworkVipCreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -84,8 +84,8 @@ Heartbeat
 			lwCliInst.Die(err)
 		}
 
-		fmt.Printf("Created VIP [%s] with uniq_id [%s]\n", details.Domain, details.UniqId)
-		fmt.Printf("\nsee 'cloud network vip details --uniq_id %s' for further details\n", details.UniqId)
+		fmt.Printf("Created VIP [%s] with uniq-id [%s]\n", details.Domain, details.UniqId)
+		fmt.Printf("\nsee 'cloud network vip details --uniq-id %s' for further details\n", details.UniqId)
 	},
 }
 

--- a/cmd/cloudNetworkVipDelete.go
+++ b/cmd/cloudNetworkVipDelete.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -61,7 +61,7 @@ Pacemaker
 Heartbeat
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -86,7 +86,7 @@ Heartbeat
 
 func init() {
 	cloudNetworkVipCmd.AddCommand(cloudNetworkVipDeleteCmd)
-	cloudNetworkVipDeleteCmd.Flags().String("uniq_id", "", "uniq_id of VIP to delete")
+	cloudNetworkVipDeleteCmd.Flags().String("uniq-id", "", "uniq-id of VIP to delete")
 
-	cloudNetworkVipDeleteCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkVipDeleteCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudNetworkVipDetails.go
+++ b/cmd/cloudNetworkVipDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -61,7 +61,7 @@ Pacemaker
 Heartbeat
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -86,7 +86,7 @@ Heartbeat
 
 func init() {
 	cloudNetworkVipCmd.AddCommand(cloudNetworkVipDetailsCmd)
-	cloudNetworkVipDetailsCmd.Flags().String("uniq_id", "", "uniq_id of VIP")
+	cloudNetworkVipDetailsCmd.Flags().String("uniq-id", "", "uniq-id of VIP")
 
-	cloudNetworkVipDetailsCmd.MarkFlagRequired("uniq_id")
+	cloudNetworkVipDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -38,7 +38,7 @@ Private Parents must use a config of category 'bare-metal' or 'bare-metal-r'. Fo
 of configs, check 'cloud server options --configs'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		nameFlag, _ := cmd.Flags().GetString("name")
-		configIdFlag, _ := cmd.Flags().GetInt64("config_id")
+		configIdFlag, _ := cmd.Flags().GetInt64("config-id")
 		zoneFlag, _ := cmd.Flags().GetInt64("zone")
 
 		validateFields := map[interface{}]interface{}{
@@ -69,11 +69,11 @@ of configs, check 'cloud server options --configs'.`,
 func init() {
 	cloudPrivateParentCmd.AddCommand(cloudPrivateParentCreateCmd)
 
-	cloudPrivateParentCreateCmd.Flags().Int64("config_id", -1, "config_id (category must be bare-metal or bare-metal-r)")
+	cloudPrivateParentCreateCmd.Flags().Int64("config-id", -1, "config-id (category must be bare-metal or bare-metal-r)")
 	cloudPrivateParentCreateCmd.Flags().String("name", "", "name for your Private Parent")
 	cloudPrivateParentCreateCmd.Flags().Int64("zone", -1, "id number of the zone to provision the Private Parent in ('cloud server options --zones')")
 
-	cloudPrivateParentCreateCmd.MarkFlagRequired("config_id")
+	cloudPrivateParentCreateCmd.MarkFlagRequired("config-id")
 	cloudPrivateParentCreateCmd.MarkFlagRequired("zone")
 	cloudPrivateParentCreateCmd.MarkFlagRequired("name")
 }

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -61,7 +61,7 @@ of configs, check 'cloud server options --configs'.`,
 			lwCliInst.Die(err)
 		}
 
-		fmt.Printf("Private Parent with name [%s] uniq_id [%s] created!\n", details.Domain, details.UniqId)
+		fmt.Printf("Private Parent with name [%s] uniq-id [%s] created!\n", details.Domain, details.UniqId)
 		fmt.Printf("\tYou can now provision Cloud Servers on this Private Parent. See 'help cloud server create'\n")
 	},
 }

--- a/cmd/cloudPrivateParentDelete.go
+++ b/cmd/cloudPrivateParentDelete.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudPrivateParentDeleteCmd = &cobra.Command{
@@ -69,7 +69,7 @@ as well as how many resources each Cloud Server gets.`,
 func init() {
 	cloudPrivateParentCmd.AddCommand(cloudPrivateParentDeleteCmd)
 
-	cloudPrivateParentDeleteCmd.Flags().String("name", "", "name or uniq_id of the Private Parent")
+	cloudPrivateParentDeleteCmd.Flags().String("name", "", "name or uniq-id of the Private Parent")
 	cloudPrivateParentDeleteCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
 	cloudPrivateParentDeleteCmd.MarkFlagRequired("name")

--- a/cmd/cloudPrivateParentDetails.go
+++ b/cmd/cloudPrivateParentDetails.go
@@ -18,9 +18,8 @@ package cmd
 import (
 	"fmt"
 
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/spf13/cobra"
-
-	"github.com/liquidweb/liquidweb-cli/types/api"
 )
 
 var cloudPrivateParentDetailsCmd = &cobra.Command{
@@ -59,6 +58,6 @@ as well as how many resources each Cloud Server gets.`,
 func init() {
 	cloudPrivateParentCmd.AddCommand(cloudPrivateParentDetailsCmd)
 
-	cloudPrivateParentDetailsCmd.Flags().String("name", "", "name or uniq_id of the Private Parent")
+	cloudPrivateParentDetailsCmd.Flags().String("name", "", "name or uniq-id of the Private Parent")
 	cloudPrivateParentDetailsCmd.MarkFlagRequired("name")
 }

--- a/cmd/cloudPrivateParentRename.go
+++ b/cmd/cloudPrivateParentRename.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -34,7 +34,7 @@ will be able to provision Cloud Servers on a Private Parent. In addition, with P
 Parents you have total control of how many instances can live on the Private Parent,
 as well as how many resources each Cloud Server gets.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		nameFlag, _ := cmd.Flags().GetString("name")
 
 		validateFields := map[interface{}]interface{}{
@@ -63,9 +63,9 @@ as well as how many resources each Cloud Server gets.`,
 func init() {
 	cloudPrivateParentCmd.AddCommand(cloudPrivateParentRenameCmd)
 
-	cloudPrivateParentRenameCmd.Flags().String("uniq_id", "", "uniq_id of the Private Parent")
+	cloudPrivateParentRenameCmd.Flags().String("uniq-id", "", "uniq-id of the Private Parent")
 	cloudPrivateParentRenameCmd.Flags().String("name", "", "name to give the Private Parent")
 
-	cloudPrivateParentRenameCmd.MarkFlagRequired("uniq_id")
+	cloudPrivateParentRenameCmd.MarkFlagRequired("uniq-id")
 	cloudPrivateParentRenameCmd.MarkFlagRequired("name")
 }

--- a/cmd/cloudServerBlockStorageOptimizedCheck.go
+++ b/cmd/cloudServerBlockStorageOptimizedCheck.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -36,7 +36,7 @@ to the Cloud Server to give more to the hypervisor. We call this Cloud Block
 Storage Optimized.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -65,7 +65,7 @@ Storage Optimized.`,
 
 func init() {
 	cloudServerBlockStorageOptimizedCmd.AddCommand(cloudServerBlockStorageOptimizedCheckCmd)
-	cloudServerBlockStorageOptimizedCheckCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
+	cloudServerBlockStorageOptimizedCheckCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
 
-	cloudServerBlockStorageOptimizedCheckCmd.MarkFlagRequired("uniq_id")
+	cloudServerBlockStorageOptimizedCheckCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerBlockStorageOptimizedDisable.go
+++ b/cmd/cloudServerBlockStorageOptimizedDisable.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -38,7 +38,7 @@ Storage Optimized.
 Disabling Cloud Block Storage will cause your Cloud Server to reboot.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -73,7 +73,7 @@ Disabling Cloud Block Storage will cause your Cloud Server to reboot.`,
 
 func init() {
 	cloudServerBlockStorageOptimizedCmd.AddCommand(cloudServerBlockStorageOptimizedDisableCmd)
-	cloudServerBlockStorageOptimizedDisableCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
+	cloudServerBlockStorageOptimizedDisableCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
 
-	cloudServerBlockStorageOptimizedDisableCmd.MarkFlagRequired("uniq_id")
+	cloudServerBlockStorageOptimizedDisableCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerBlockStorageOptimizedEnable.go
+++ b/cmd/cloudServerBlockStorageOptimizedEnable.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -38,7 +38,7 @@ Storage Optimized.
 Enabling Cloud Block Storage will cause your Cloud Server to reboot.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -73,7 +73,7 @@ Enabling Cloud Block Storage will cause your Cloud Server to reboot.`,
 
 func init() {
 	cloudServerBlockStorageOptimizedCmd.AddCommand(cloudServerBlockStorageOptimizedEnableCmd)
-	cloudServerBlockStorageOptimizedEnableCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server")
+	cloudServerBlockStorageOptimizedEnableCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
 
-	cloudServerBlockStorageOptimizedEnableCmd.MarkFlagRequired("uniq_id")
+	cloudServerBlockStorageOptimizedEnableCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -41,13 +41,13 @@ Server where possible.
 
 ** Cloning to a Private Parent: **
 
---private-parent must be passed containing either the uniq_id of the Private Parent,
+--private-parent must be passed containing either the uniq-id of the Private Parent,
 or its name.
 
 The flags --diskspace --vcpu --memory must all be passed if the source Cloud
 Server is not on a Private Parent.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		passwordFlag, _ := cmd.Flags().GetString("password")
 		zoneFlag, _ := cmd.Flags().GetInt64("zone")
 		newIpsFlag, _ := cmd.Flags().GetInt64("new_ips")
@@ -129,7 +129,7 @@ Server is not on a Private Parent.`,
 		}
 
 		fmt.Printf(
-			"Success! Cloning existing Cloud Server [%s] to new Cloud Server [%s]. Check status with 'cloud server status --uniq_id %s'\n",
+			"Success! Cloning existing Cloud Server [%s] to new Cloud Server [%s]. Check status with 'cloud server status --uniq-id %s'\n",
 			uniqIdFlag, details.UniqId, uniqIdFlag)
 
 	},
@@ -139,7 +139,7 @@ func init() {
 	cloudServerCmd.AddCommand(cloudServerCloneCmd)
 
 	// General
-	cloudServerCloneCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Server to clone")
+	cloudServerCloneCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server to clone")
 	cloudServerCloneCmd.Flags().String("password", "", "root or administrator password for new Cloud Server")
 	cloudServerCloneCmd.Flags().Int64("zone", -1, "zone for new Cloud Server")
 	cloudServerCloneCmd.Flags().Int64("new_ips", 1, "amount of IP addresses for new Cloud Server")
@@ -150,7 +150,7 @@ func init() {
 
 	// Private Parent
 	cloudServerCloneCmd.Flags().String("private-parent", "",
-		"name or uniq_id of the Private Parent to place new Cloud Server on (see: 'cloud private-parent list')")
+		"name or uniq-id of the Private Parent to place new Cloud Server on (see: 'cloud private-parent list')")
 	cloudServerCloneCmd.Flags().Int64("diskspace", -1, "diskspace for new Cloud Server (when private-parent)")
 	cloudServerCloneCmd.Flags().Int64("memory", -1, "memory for new Cloud Server (when private-parent)")
 	cloudServerCloneCmd.Flags().Int64("vcpu", -1, "amount of vcpus for new Cloud Server (when private-parent)")
@@ -159,5 +159,5 @@ func init() {
 	cloudServerCloneCmd.Flags().Int64("config_id", -1,
 		"config_id for new Cloud Server (when !private-parent) (see: 'cloud server options --configs')")
 
-	cloudServerCloneCmd.MarkFlagRequired("uniq_id")
+	cloudServerCloneCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -50,7 +50,7 @@ Server is not on a Private Parent.`,
 		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		passwordFlag, _ := cmd.Flags().GetString("password")
 		zoneFlag, _ := cmd.Flags().GetInt64("zone")
-		newIpsFlag, _ := cmd.Flags().GetInt64("new_ips")
+		newIpsFlag, _ := cmd.Flags().GetInt64("new-ips")
 		hostnameFlag, _ := cmd.Flags().GetString("hostname")
 		privateParentFlag, _ := cmd.Flags().GetString("private-parent")
 		diskspaceFlag, _ := cmd.Flags().GetInt64("diskspace")
@@ -142,7 +142,7 @@ func init() {
 	cloudServerCloneCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server to clone")
 	cloudServerCloneCmd.Flags().String("password", "", "root or administrator password for new Cloud Server")
 	cloudServerCloneCmd.Flags().Int64("zone", -1, "zone for new Cloud Server")
-	cloudServerCloneCmd.Flags().Int64("new_ips", 1, "amount of IP addresses for new Cloud Server")
+	cloudServerCloneCmd.Flags().Int64("new-ips", 1, "amount of IP addresses for new Cloud Server")
 	cloudServerCloneCmd.Flags().String("hostname", fmt.Sprintf("%s.%s.io", utils.RandomString(4),
 		utils.RandomString(10)), "hostname for new Cloud Server")
 	cloudServerCloneCmd.Flags().StringSliceVar(&cloudServerCloneCmdPoolIpsFlag, "pool-ips", []string{},

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -56,7 +56,7 @@ Server is not on a Private Parent.`,
 		diskspaceFlag, _ := cmd.Flags().GetInt64("diskspace")
 		memoryFlag, _ := cmd.Flags().GetInt64("memory")
 		vcpuFlag, _ := cmd.Flags().GetInt64("vcpu")
-		configIdFlag, _ := cmd.Flags().GetInt64("config_id")
+		configIdFlag, _ := cmd.Flags().GetInt64("config-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -65,10 +65,10 @@ Server is not on a Private Parent.`,
 		}
 
 		if privateParentFlag != "" && configIdFlag != -1 {
-			lwCliInst.Die(fmt.Errorf("cant pass both --config_id and --private-parent flags"))
+			lwCliInst.Die(fmt.Errorf("cant pass both --config-id and --private-parent flags"))
 		}
 		if privateParentFlag == "" && configIdFlag == -1 {
-			lwCliInst.Die(fmt.Errorf("must pass --config_id or --private-parent"))
+			lwCliInst.Die(fmt.Errorf("must pass --config-id or --private-parent"))
 		}
 
 		var privateParentUniqId string
@@ -156,8 +156,8 @@ func init() {
 	cloudServerCloneCmd.Flags().Int64("vcpu", -1, "amount of vcpus for new Cloud Server (when private-parent)")
 
 	// Non Private Parent
-	cloudServerCloneCmd.Flags().Int64("config_id", -1,
-		"config_id for new Cloud Server (when !private-parent) (see: 'cloud server options --configs')")
+	cloudServerCloneCmd.Flags().Int64("config-id", -1,
+		"config-id for new Cloud Server (when !private-parent) (see: 'cloud server options --configs')")
 
 	cloudServerCloneCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -70,7 +70,7 @@ For a list of backups, see 'cloud backups list'
 		bandwidthFlag, _ := cmd.Flags().GetString("bandwidth")
 		zoneFlag, _ := cmd.Flags().GetInt("zone")
 		winavFlag, _ := cmd.Flags().GetString("winav")
-		msSqlFlag, _ := cmd.Flags().GetString("ms_sql")
+		msSqlFlag, _ := cmd.Flags().GetString("ms-sql")
 		privateParentFlag, _ := cmd.Flags().GetString("private-parent")
 		passwordFlag, _ := cmd.Flags().GetString("password")
 		memoryFlag, _ := cmd.Flags().GetInt("memory")

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -240,7 +240,7 @@ For a list of backups, see 'cloud backups list'
 
 		resultUniqId := result.(map[string]interface{})["uniq_id"]
 		fmt.Printf(
-			"Cloud server with uniq_id [%s] creating. Check status with 'cloud server status --uniq_id %s'\n",
+			"Cloud server with uniq-id [%s] creating. Check status with 'cloud server status --uniq-id %s'\n",
 			resultUniqId, resultUniqId)
 	},
 }
@@ -278,7 +278,7 @@ func init() {
 
 	// private parent specific
 	cloudServerCreateCmd.Flags().String("private-parent", "",
-		"name or uniq_id of the private-parent. Must use when creating a Cloud Server on a private parent.")
+		"name or uniq-id of the private-parent. Must use when creating a Cloud Server on a private parent.")
 	cloudServerCreateCmd.Flags().Int("memory", -1, "memory (ram) value use with --private-parent")
 	cloudServerCreateCmd.Flags().Int("diskspace", -1, "diskspace value use with --private-parent")
 	cloudServerCreateCmd.Flags().Int("vcpu", -1, "vcpu value use with --private-parent")

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -43,14 +43,14 @@ Examples:
 # Create a Cloud Server on a Private Parent named "private"
 'cloud server create --private-parent private --memory 1024 --diskspace 40 --vcpu 2 --zone 40460 --template DEBIAN_10_UNMANAGED'
 
-# Create a Cloud Server on config_id 1
-'cloud server create --config_id 1 --template DEBIAN_10_UNMANAGED --zone 40460'
+# Create a Cloud Server on config-id 1
+'cloud server create --config-id 1 --template DEBIAN_10_UNMANAGED --zone 40460'
 
 # Create a Cloud Server from image id 111
-'cloud server create --image-id 111 --zone 40460 --config_id 1'
+'cloud server create --image-id 111 --zone 40460 --config-id 1'
 
 # Create a Cloud Server from backup id 111
-'cloud server create --backup-id 111 --zone 40460 --config_id 1'
+'cloud server create --backup-id 111 --zone 40460 --config-id 1'
 
 These examples use default values for various flags, such as password, type, ssh-key, hostname, etc.
 
@@ -64,7 +64,7 @@ For a list of backups, see 'cloud backups list'
 		hostnameFlag, _ := cmd.Flags().GetString("hostname")
 		ipsFlag, _ := cmd.Flags().GetInt("ips")
 		pubSshKeyFlag, _ := cmd.Flags().GetString("public-ssh-key")
-		configIdFlag, _ := cmd.Flags().GetInt("config_id")
+		configIdFlag, _ := cmd.Flags().GetInt("config-id")
 		backupPlanFlag, _ := cmd.Flags().GetString("backup-plan")
 		backupPlanQuotaFlag, _ := cmd.Flags().GetInt("backup-plan-quota")
 		bandwidthFlag, _ := cmd.Flags().GetString("bandwidth")
@@ -81,7 +81,7 @@ For a list of backups, see 'cloud backups list'
 
 		// sanity check flags
 		if configIdFlag == 0 && privateParentFlag == "" {
-			lwCliInst.Die(fmt.Errorf("--config_id is a required flag without --private-parent"))
+			lwCliInst.Die(fmt.Errorf("--config-id is a required flag without --private-parent"))
 		}
 		if templateFlag == "" && backupIdFlag == -1 && imageIdFlag == -1 {
 			lwCliInst.Die(fmt.Errorf("at least one of the following flags must be set --template --image-id --backup-id"))
@@ -263,7 +263,7 @@ func init() {
 	cloudServerCreateCmd.Flags().Int("ips", 1, "amount of IP addresses")
 	cloudServerCreateCmd.Flags().String("public-ssh-key", sshPubKeyFile,
 		"path to file containing the public ssh key you wish to be on the new Cloud Server")
-	cloudServerCreateCmd.Flags().Int("config_id", 0, "config_id to use")
+	cloudServerCreateCmd.Flags().Int("config-id", 0, "config-id to use")
 	cloudServerCreateCmd.Flags().String("backup-plan", "None", "Cloud Server backup plan to use")
 	cloudServerCreateCmd.Flags().Int("backup-plan-quota", 300, "Quota amount. Should only be used with '--backup-plan Quota'")
 	cloudServerCreateCmd.Flags().String("bandwidth", "SS.10000", "bandwidth package to use")

--- a/cmd/cloudServerDestroy.go
+++ b/cmd/cloudServerDestroy.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -82,13 +82,13 @@ server.`,
 func init() {
 	cloudServerCmd.AddCommand(cloudServerDestroyCmd)
 
-	cloudServerDestroyCmd.Flags().StringSliceVar(&cloudServerDestroyCmdUniqIdFlag, "uniq_id",
-		[]string{}, "uniq_ids separated by ',' of server(s) to destroy")
+	cloudServerDestroyCmd.Flags().StringSliceVar(&cloudServerDestroyCmdUniqIdFlag, "uniq-id",
+		[]string{}, "uniq-ids separated by ',' of server(s) to destroy")
 	cloudServerDestroyCmd.Flags().String("comment", "initiated from liquidweb-cli",
 		"comment related to the cancellation")
 	cloudServerDestroyCmd.Flags().String("reason", "",
 		"reason for the cancellation (optional)")
 	cloudServerDestroyCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
-	cloudServerDestroyCmd.MarkFlagRequired("uniq_id")
+	cloudServerDestroyCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerDetails.go
+++ b/cmd/cloudServerDetails.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -39,7 +39,7 @@ You can check this methods API documentation for what the returned fields mean:
 https://cart.liquidweb.com/storm/api/docs/bleed/Storm/Server.html#method_details
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		jsonFlag, _ := cmd.Flags().GetBool("json")
 
 		validateFields := map[interface{}]interface{}{
@@ -122,7 +122,7 @@ func init() {
 	cloudServerCmd.AddCommand(cloudServerDetailsCmd)
 
 	cloudServerDetailsCmd.Flags().Bool("json", false, "output in json format")
-	cloudServerDetailsCmd.Flags().String("uniq_id", "", "get details of this uniq_id")
+	cloudServerDetailsCmd.Flags().String("uniq-id", "", "get details of this uniq-id")
 
-	cloudServerDetailsCmd.MarkFlagRequired("uniq_id")
+	cloudServerDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerOptions.go
+++ b/cmd/cloudServerOptions.go
@@ -35,7 +35,7 @@ Use this when you need to get a list of available:
 
 *) Regions/Zones
 *) Templates (cloud server images provided by LiquidWeb)
-*) config_id's (a config_id represents a type of server, for example, config_id 1234 might
+*) config-id's (a config-id represents a type of server, for example, config-id 1234 might
    represent a configuration with the following hardware specifications:
      *) 16GB RAM
      *) 300GB Disk
@@ -190,7 +190,7 @@ Be sure to take a look at the flags section for specific flags to pass.`,
 				if configsFlag {
 					fmt.Printf("  configs:\n")
 					for _, cfgInfo := range info["configIds"].([]map[string]interface{}) {
-						fmt.Printf("    config_id: %d\n", cfgInfo["config_id"])
+						fmt.Printf("    config-id: %d\n", cfgInfo["config_id"])
 						fmt.Printf("      description: %s\n", cfgInfo["description"])
 						fmt.Printf("      active: %d\n", cfgInfo["active"])
 						fmt.Printf("      available: %d\n", cfgInfo["available"])
@@ -240,7 +240,7 @@ func init() {
 	cloudServerCmd.AddCommand(cloudServerOptionsCmd)
 
 	cloudServerOptionsCmd.Flags().Bool("json", false, "return data in json format. All template, config, zone, and region data will be returned with this option.")
-	cloudServerOptionsCmd.Flags().Bool("configs", false, "fetch a list of available configs (config_id)")
+	cloudServerOptionsCmd.Flags().Bool("configs", false, "fetch a list of available configs (config-id)")
 	cloudServerOptionsCmd.Flags().String("config-category", "all", "valid options for category are storm, ssd, bare-metal and all. Only relevent when --configs is passed.")
 	cloudServerOptionsCmd.Flags().Bool("zones", false, "fetch a list of available regions and their available zones")
 	cloudServerOptionsCmd.Flags().Bool("templates", false, "fetch a list of available templates (cloud server images provided by LiquidWeb)")

--- a/cmd/cloudServerReboot.go
+++ b/cmd/cloudServerReboot.go
@@ -20,18 +20,18 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
 var cloudServerRebootCmd = &cobra.Command{
 	Use:   "reboot",
 	Short: "Reboot a Cloud Server",
-	Long: `Reboots the cloud server as specified by the uniq_id flag.
+	Long: `Reboots the cloud server as specified by the uniq-id flag.
 
 To perform a forced a reboot, you must use --force`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqId, _ := cmd.Flags().GetString("uniq_id")
+		uniqId, _ := cmd.Flags().GetString("uniq-id")
 		jsonOutput, _ := cmd.Flags().GetBool("json")
 		force, _ := cmd.Flags().GetBool("force")
 
@@ -65,7 +65,7 @@ func init() {
 
 	cloudServerRebootCmd.Flags().Bool("json", false, "output in json format")
 	cloudServerRebootCmd.Flags().Bool("force", false, "perform a forced reboot")
-	cloudServerRebootCmd.Flags().String("uniq_id", "", "uniq_id of server to reboot")
+	cloudServerRebootCmd.Flags().String("uniq-id", "", "uniq-id of server to reboot")
 
-	cloudServerRebootCmd.MarkFlagRequired("uniq_id")
+	cloudServerRebootCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerResize.go
+++ b/cmd/cloudServerResize.go
@@ -29,7 +29,7 @@ var cloudServerResizeCmd = &cobra.Command{
 	Short: "Resize a Cloud Server",
 	Long: `Resize a Cloud Server.
 
-Resize a Cloud Server to a new config. Available config_ids can be found in
+Resize a Cloud Server to a new config. Available config-id's can be found in
 'cloud server options --configs'
 
 You will be billed for the prorated difference of the price of the new
@@ -70,7 +70,7 @@ During all resizes, the Cloud Server is online as the disk synchronizes.
 	Run: func(cmd *cobra.Command, args []string) {
 		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		diskspaceFlag, _ := cmd.Flags().GetInt64("diskspace")
-		configIdFlag, _ := cmd.Flags().GetInt64("config_id")
+		configIdFlag, _ := cmd.Flags().GetInt64("config-id")
 		memoryFlag, _ := cmd.Flags().GetInt64("memory")
 		skipFsResizeFlag, _ := cmd.Flags().GetBool("skip-fs-resize")
 		vcpuFlag, _ := cmd.Flags().GetInt64("vcpu")
@@ -91,7 +91,7 @@ During all resizes, the Cloud Server is online as the disk synchronizes.
 		}
 
 		if configIdFlag == -1 && privateParentFlag == "" {
-			lwCliInst.Die(fmt.Errorf("flag --config_id required when --private-parent is not given"))
+			lwCliInst.Die(fmt.Errorf("flag --config-id required when --private-parent is not given"))
 		}
 
 		resizeArgs := map[string]interface{}{
@@ -118,7 +118,7 @@ During all resizes, the Cloud Server is online as the disk synchronizes.
 
 			// if already on the given config, nothing to do
 			if cloudServerDetails.ConfigId == configIdFlag {
-				lwCliInst.Die(fmt.Errorf("already on config_id [%d]; not initiating a resize", configIdFlag))
+				lwCliInst.Die(fmt.Errorf("already on config-id [%d]; not initiating a resize", configIdFlag))
 			}
 
 			validateFields[configIdFlag] = "PositiveInt64"
@@ -276,8 +276,8 @@ func init() {
 	cloudServerResizeCmd.Flags().Int64("memory", -1, "desired memory (when private-parent)")
 	cloudServerResizeCmd.Flags().Bool("skip-fs-resize", false, "whether or not to skip the fs resize")
 	cloudServerResizeCmd.Flags().Int64("vcpu", -1, "desired vcpu count (when private-parent)")
-	cloudServerResizeCmd.Flags().Int64("config_id", -1,
-		"config_id of your desired config (when !private-parent) (see 'cloud server options --configs')")
+	cloudServerResizeCmd.Flags().Int64("config-id", -1,
+		"config-id of your desired config (when !private-parent) (see 'cloud server options --configs')")
 
 	cloudServerResizeCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerResize.go
+++ b/cmd/cloudServerResize.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -48,7 +48,7 @@ configuration.
 
 If this is a resize of a Cloud Server on a private parent, pass --private-parent
 with a value of either the name of the private parent, or the private parents
-uniq_id. When passing --private-parent, at least one of the following flags
+uniq-id. When passing --private-parent, at least one of the following flags
 are required:
 
   --diskspace
@@ -68,7 +68,7 @@ going to a config with more diskspace, and --skip-fs-resize wasn't passed.
 During all resizes, the Cloud Server is online as the disk synchronizes.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		diskspaceFlag, _ := cmd.Flags().GetInt64("diskspace")
 		configIdFlag, _ := cmd.Flags().GetInt64("config_id")
 		memoryFlag, _ := cmd.Flags().GetInt64("memory")
@@ -246,7 +246,7 @@ During all resizes, the Cloud Server is online as the disk synchronizes.
 			lwCliInst.Die(err)
 		}
 
-		fmt.Printf("server resized started! You can check progress with 'cloud server status --uniq_id %s'\n\n", uniqIdFlag)
+		fmt.Printf("server resized started! You can check progress with 'cloud server status --uniq-id %s'\n\n", uniqIdFlag)
 
 		if liveResize {
 			fmt.Printf("\nthis resize will be performed live without downtime.\n")
@@ -270,8 +270,8 @@ func init() {
 	cloudServerCmd.AddCommand(cloudServerResizeCmd)
 
 	cloudServerResizeCmd.Flags().String("private-parent", "",
-		"name or uniq_id of the private-parent. Must use when adding/removing resources to a Cloud Server on a private parent.")
-	cloudServerResizeCmd.Flags().String("uniq_id", "", "uniq_id of server to resize")
+		"name or uniq-id of the private-parent. Must use when adding/removing resources to a Cloud Server on a private parent.")
+	cloudServerResizeCmd.Flags().String("uniq-id", "", "uniq-id of server to resize")
 	cloudServerResizeCmd.Flags().Int64("diskspace", -1, "desired diskspace (when private-parent)")
 	cloudServerResizeCmd.Flags().Int64("memory", -1, "desired memory (when private-parent)")
 	cloudServerResizeCmd.Flags().Bool("skip-fs-resize", false, "whether or not to skip the fs resize")
@@ -279,5 +279,5 @@ func init() {
 	cloudServerResizeCmd.Flags().Int64("config_id", -1,
 		"config_id of your desired config (when !private-parent) (see 'cloud server options --configs')")
 
-	cloudServerResizeCmd.MarkFlagRequired("uniq_id")
+	cloudServerResizeCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerShutdown.go
+++ b/cmd/cloudServerShutdown.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -32,7 +32,7 @@ var cloudServerShutdownCmd = &cobra.Command{
 Stop a server. The 'force' flag will do a hard stop of the server from the parent server. Otherwise, it
 will issue a halt command to the server and shutdown normally.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		jsonFlag, _ := cmd.Flags().GetBool("json")
 
 		validateFields := map[interface{}]interface{}{
@@ -67,7 +67,7 @@ will issue a halt command to the server and shutdown normally.`,
 func init() {
 	cloudServerCmd.AddCommand(cloudServerShutdownCmd)
 	cloudServerShutdownCmd.Flags().Bool("json", false, "output in json format")
-	cloudServerShutdownCmd.Flags().String("uniq_id", "", "uniq_id of server to shutdown")
+	cloudServerShutdownCmd.Flags().String("uniq-id", "", "uniq-id of server to shutdown")
 
-	cloudServerShutdownCmd.MarkFlagRequired("uniq_id")
+	cloudServerShutdownCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerStart.go
+++ b/cmd/cloudServerStart.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -31,7 +31,7 @@ var cloudServerStartCmd = &cobra.Command{
 
 Boot a server. If the server is already running, this will do nothing.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		jsonFlag, _ := cmd.Flags().GetBool("json")
 
 		validateFields := map[interface{}]interface{}{
@@ -66,7 +66,7 @@ Boot a server. If the server is already running, this will do nothing.`,
 func init() {
 	cloudServerCmd.AddCommand(cloudServerStartCmd)
 	cloudServerStartCmd.Flags().Bool("json", false, "output in json format")
-	cloudServerStartCmd.Flags().String("uniq_id", "", "uniq_id of server to start")
+	cloudServerStartCmd.Flags().String("uniq-id", "", "uniq-id of server to start")
 
-	cloudServerStartCmd.MarkFlagRequired("uniq_id")
+	cloudServerStartCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudServerStatus.go
+++ b/cmd/cloudServerStatus.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -105,8 +105,8 @@ If nothing is currently running, only the 'status' field will be returned with o
 func init() {
 	cloudServerCmd.AddCommand(cloudServerStatusCmd)
 
-	cloudServerStatusCmd.Flags().StringSliceVar(&cloudServerStatusCmdUniqIdFlag, "uniq_id", []string{},
-		"uniq_id(s) to get status of. For multiple, must be ',' separated")
+	cloudServerStatusCmd.Flags().StringSliceVar(&cloudServerStatusCmdUniqIdFlag, "uniq-id", []string{},
+		"uniq-id(s) to get status of. For multiple, must be ',' separated")
 }
 
 func _printCloudServerStatus(uniqId string, domain string) {

--- a/cmd/cloudServerUpdate.go
+++ b/cmd/cloudServerUpdate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -36,7 +36,7 @@ on the server. It merely updates what our records show.
 bandwidth_plan is the bandwidth plan you wish to use.  A quota of 0 indicates that you want
 as-you-go, usage-based bandwidth charges.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		hostnameFlag, _ := cmd.Flags().GetString("hostname")
 		backupPlanFlag, _ := cmd.Flags().GetString("backup-plan")
 		disableBackupsFlag, _ := cmd.Flags().GetBool("disable-backups")
@@ -99,7 +99,7 @@ as-you-go, usage-based bandwidth charges.`,
 func init() {
 	cloudServerCmd.AddCommand(cloudServerUpdateCmd)
 
-	cloudServerUpdateCmd.Flags().String("uniq_id", "", "uniq_id of the Cloud Server")
+	cloudServerUpdateCmd.Flags().String("uniq-id", "", "uniq-id of the Cloud Server")
 	cloudServerUpdateCmd.Flags().String("hostname", "", "hostname to set")
 	cloudServerUpdateCmd.Flags().String("backup-plan", "", "Name of the backup plan")
 	cloudServerUpdateCmd.Flags().Int64("backup-quota", -1, "Quota to set for Quota type backup-plan")
@@ -107,5 +107,5 @@ func init() {
 	cloudServerUpdateCmd.Flags().Int64("bandwidth-quota", -1,
 		"bandwidth quota (0 indicates as-you-go, usage-based bandwidth charges)")
 
-	cloudServerUpdateCmd.MarkFlagRequired("uniq_id")
+	cloudServerUpdateCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudStorageBlockVolumeAttach.go
+++ b/cmd/cloudStorageBlockVolumeAttach.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ Block storage offers a method to attach additional storage to Cloud Server.
 Once attached, volumes appear as normal block devices, and can be used as such.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		attachToFlag, _ := cmd.Flags().GetString("attach-to")
 
 		validateFields := map[interface{}]interface{}{
@@ -64,11 +64,11 @@ Once attached, volumes appear as normal block devices, and can be used as such.
 func init() {
 	cloudStorageBlockVolumeCmd.AddCommand(cloudStorageBlockVolumeAttachCmd)
 
-	cloudStorageBlockVolumeAttachCmd.Flags().String("uniq_id", "",
-		"uniq_id of Cloud Block Storage Volume")
+	cloudStorageBlockVolumeAttachCmd.Flags().String("uniq-id", "",
+		"uniq-id of Cloud Block Storage Volume")
 	cloudStorageBlockVolumeAttachCmd.Flags().String("attach-to", "",
-		"uniq_id of Cloud Server to attach to")
+		"uniq-id of Cloud Server to attach to")
 
-	cloudStorageBlockVolumeAttachCmd.MarkFlagRequired("uniq_id")
+	cloudStorageBlockVolumeAttachCmd.MarkFlagRequired("uniq-id")
 	cloudStorageBlockVolumeAttachCmd.MarkFlagRequired("attach-to")
 }

--- a/cmd/cloudStorageBlockVolumeCreate.go
+++ b/cmd/cloudStorageBlockVolumeCreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -84,7 +84,7 @@ func init() {
 	cloudStorageBlockVolumeCreateCmd.Flags().String("name", fmt.Sprintf("bsv-%s", utils.RandomString(5)),
 		"Name for Block Storage volume")
 	cloudStorageBlockVolumeCreateCmd.Flags().Bool("cross-attach", false, "Enable cross attach for Block Storage volume")
-	cloudStorageBlockVolumeCreateCmd.Flags().String("attach", "", "uniq_id to attach created Block Storage volume to")
+	cloudStorageBlockVolumeCreateCmd.Flags().String("attach", "", "uniq-id to attach created Block Storage volume to")
 
 	cloudStorageBlockVolumeCreateCmd.MarkFlagRequired("size")
 }

--- a/cmd/cloudStorageBlockVolumeDelete.go
+++ b/cmd/cloudStorageBlockVolumeDelete.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -34,7 +34,7 @@ Block storage offers a method to attach additional storage to Cloud Server.
 Once attached, volumes appear as normal block devices, and can be used as such.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		forceFlag, _ := cmd.Flags().GetBool("force")
 
 		// if force flag wasn't passed
@@ -66,8 +66,8 @@ Once attached, volumes appear as normal block devices, and can be used as such.
 func init() {
 	cloudStorageBlockVolumeCmd.AddCommand(cloudStorageBlockVolumeDeleteCmd)
 
-	cloudStorageBlockVolumeDeleteCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Block Storage volume")
+	cloudStorageBlockVolumeDeleteCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Block Storage volume")
 	cloudStorageBlockVolumeDeleteCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
-	cloudStorageBlockVolumeDeleteCmd.MarkFlagRequired("uniq_id")
+	cloudStorageBlockVolumeDeleteCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudStorageBlockVolumeDetach.go
+++ b/cmd/cloudStorageBlockVolumeDetach.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ Block storage offers a method to attach additional storage to Cloud Server.
 Once attached, volumes appear as normal block devices, and can be used as such.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		detachFromFlag, _ := cmd.Flags().GetString("detach-from")
 
 		validateFields := map[interface{}]interface{}{
@@ -64,11 +64,11 @@ Once attached, volumes appear as normal block devices, and can be used as such.
 func init() {
 	cloudStorageBlockVolumeCmd.AddCommand(cloudStorageBlockVolumeDetachCmd)
 
-	cloudStorageBlockVolumeDetachCmd.Flags().String("uniq_id", "",
-		"uniq_id of Cloud Block Storage Volume")
+	cloudStorageBlockVolumeDetachCmd.Flags().String("uniq-id", "",
+		"uniq-id of Cloud Block Storage Volume")
 	cloudStorageBlockVolumeDetachCmd.Flags().String("detach-from", "",
-		"uniq_id of Cloud Server to detach from")
+		"uniq-id of Cloud Server to detach from")
 
-	cloudStorageBlockVolumeDetachCmd.MarkFlagRequired("uniq_id")
+	cloudStorageBlockVolumeDetachCmd.MarkFlagRequired("uniq-id")
 	cloudStorageBlockVolumeDetachCmd.MarkFlagRequired("detach-from")
 }

--- a/cmd/cloudStorageBlockVolumeDetails.go
+++ b/cmd/cloudStorageBlockVolumeDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ Block storage offers a method to attach additional storage to Cloud Server.
 Once attached, volumes appear as normal block devices, and can be used as such.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		jsonFlag, _ := cmd.Flags().GetBool("json")
 
 		validateFields := map[interface{}]interface{}{
@@ -68,7 +68,7 @@ func init() {
 	cloudStorageBlockVolumeCmd.AddCommand(cloudStorageBlockVolumeDetailsCmd)
 
 	cloudStorageBlockVolumeDetailsCmd.Flags().Bool("json", false, "output in json format")
-	cloudStorageBlockVolumeDetailsCmd.Flags().String("uniq_id", "", "uniq_id of Cloud Block Storage volume")
+	cloudStorageBlockVolumeDetailsCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Block Storage volume")
 
-	cloudStorageBlockVolumeDetailsCmd.MarkFlagRequired("uniq_id")
+	cloudStorageBlockVolumeDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudStorageBlockVolumeResize.go
+++ b/cmd/cloudStorageBlockVolumeResize.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ Block storage offers a method to attach additional storage to Cloud Server.
 Once attached, volumes appear as normal block devices, and can be used as such.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		newSizeFlag, _ := cmd.Flags().GetInt64("new-size")
 
 		validateFields := map[interface{}]interface{}{
@@ -64,11 +64,11 @@ Once attached, volumes appear as normal block devices, and can be used as such.
 func init() {
 	cloudStorageBlockVolumeCmd.AddCommand(cloudStorageBlockVolumeResizeCmd)
 
-	cloudStorageBlockVolumeResizeCmd.Flags().String("uniq_id", "",
-		"uniq_id of Cloud Block Storage Volume")
+	cloudStorageBlockVolumeResizeCmd.Flags().String("uniq-id", "",
+		"uniq-id of Cloud Block Storage Volume")
 	cloudStorageBlockVolumeResizeCmd.Flags().Int64("new-size", -1,
 		"size (gb) to resize the volume to")
 
-	cloudStorageBlockVolumeResizeCmd.MarkFlagRequired("uniq_id")
+	cloudStorageBlockVolumeResizeCmd.MarkFlagRequired("uniq-id")
 	cloudStorageBlockVolumeResizeCmd.MarkFlagRequired("new-size")
 }

--- a/cmd/cloudStorageBlockVolumeUpdate.go
+++ b/cmd/cloudStorageBlockVolumeUpdate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ Block storage offers a method to attach additional storage to Cloud Server.
 Once attached, volumes appear as normal block devices, and can be used as such.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		nameFlag, _ := cmd.Flags().GetString("name")
 		enableCrossAttachFlag, _ := cmd.Flags().GetBool("enable-cross-attach")
 		disableCrossAttachFlag, _ := cmd.Flags().GetBool("disable-cross-attach")
@@ -77,8 +77,8 @@ Once attached, volumes appear as normal block devices, and can be used as such.
 func init() {
 	cloudStorageBlockVolumeCmd.AddCommand(cloudStorageBlockVolumeUpdateCmd)
 
-	cloudStorageBlockVolumeUpdateCmd.Flags().String("uniq_id", "",
-		"uniq_id of Cloud Block Storage Volume")
+	cloudStorageBlockVolumeUpdateCmd.Flags().String("uniq-id", "",
+		"uniq-id of Cloud Block Storage Volume")
 	cloudStorageBlockVolumeUpdateCmd.Flags().String("name", "",
 		"new name for the Cloud Block Storage Volume")
 	cloudStorageBlockVolumeUpdateCmd.Flags().Bool("enable-cross-attach", false,
@@ -86,5 +86,5 @@ func init() {
 	cloudStorageBlockVolumeUpdateCmd.Flags().Bool("disable-cross-attach", false,
 		"disable cross attach for Cloud Block Storage Volume")
 
-	cloudStorageBlockVolumeUpdateCmd.MarkFlagRequired("uniq_id")
+	cloudStorageBlockVolumeUpdateCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudStorageObjectCreateKey.go
+++ b/cmd/cloudStorageObjectCreateKey.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var cloudStorageObjectCreateKeyCmd = &cobra.Command{
 	Short: "Create a new key for the Object Store",
 	Long:  `Create a new key for the Object Store`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -57,7 +57,7 @@ var cloudStorageObjectCreateKeyCmd = &cobra.Command{
 
 func init() {
 	cloudStorageObjectCmd.AddCommand(cloudStorageObjectCreateKeyCmd)
-	cloudStorageObjectCreateKeyCmd.Flags().String("uniq_id", "", "uniq_id of Object Store")
+	cloudStorageObjectCreateKeyCmd.Flags().String("uniq-id", "", "uniq-id of Object Store")
 
-	cloudStorageObjectCreateKeyCmd.MarkFlagRequired("uniq_id")
+	cloudStorageObjectCreateKeyCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudStorageObjectDelete.go
+++ b/cmd/cloudStorageObjectDelete.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -30,7 +30,7 @@ var cloudStorageObjectDeleteCmd = &cobra.Command{
 	Short: "Delete an Object Store",
 	Long:  `Delete an Object Store`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		forceFlag, _ := cmd.Flags().GetBool("force")
 
 		// if force flag wasn't passed
@@ -62,9 +62,9 @@ var cloudStorageObjectDeleteCmd = &cobra.Command{
 
 func init() {
 	cloudStorageObjectCmd.AddCommand(cloudStorageObjectDeleteCmd)
-	cloudStorageObjectDeleteCmd.Flags().String("uniq_id", "",
-		"uniq_id of object store to delete (see 'cloud storage object list')")
+	cloudStorageObjectDeleteCmd.Flags().String("uniq-id", "",
+		"uniq-id of object store to delete (see 'cloud storage object list')")
 	cloudStorageObjectDeleteCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
-	cloudStorageObjectDeleteCmd.MarkFlagRequired("uniq_id")
+	cloudStorageObjectDeleteCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/cloudStorageObjectDeleteKey.go
+++ b/cmd/cloudStorageObjectDeleteKey.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -30,7 +30,7 @@ var cloudStorageObjectDeleteKeyCmd = &cobra.Command{
 	Short: "Delete a key from the Object Store",
 	Long:  `Delete a key from the Object Store`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		accessKeyFlag, _ := cmd.Flags().GetString("access-key")
 		forceFlag, _ := cmd.Flags().GetBool("force")
 
@@ -67,10 +67,10 @@ var cloudStorageObjectDeleteKeyCmd = &cobra.Command{
 
 func init() {
 	cloudStorageObjectCmd.AddCommand(cloudStorageObjectDeleteKeyCmd)
-	cloudStorageObjectDeleteKeyCmd.Flags().String("uniq_id", "", "uniq_id of Object Store")
+	cloudStorageObjectDeleteKeyCmd.Flags().String("uniq-id", "", "uniq-id of Object Store")
 	cloudStorageObjectDeleteKeyCmd.Flags().String("access-key", "", "the access key to remove from the Object Store")
 	cloudStorageObjectDeleteKeyCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
-	cloudStorageObjectDeleteKeyCmd.MarkFlagRequired("uniq_id")
+	cloudStorageObjectDeleteKeyCmd.MarkFlagRequired("uniq-id")
 	cloudStorageObjectDeleteKeyCmd.MarkFlagRequired("access-key")
 }

--- a/cmd/cloudStorageObjectDetails.go
+++ b/cmd/cloudStorageObjectDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var cloudStorageObjectDetailsCmd = &cobra.Command{
 	Short: "Get details of a Object Store",
 	Long:  `Get details of a Object Store`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -52,7 +52,7 @@ var cloudStorageObjectDetailsCmd = &cobra.Command{
 
 func init() {
 	cloudStorageObjectCmd.AddCommand(cloudStorageObjectDetailsCmd)
-	cloudStorageObjectDetailsCmd.Flags().String("uniq_id", "", "uniq_id of the object store")
+	cloudStorageObjectDetailsCmd.Flags().String("uniq-id", "", "uniq-id of the object store")
 
-	cloudStorageObjectDetailsCmd.MarkFlagRequired("uniq_id")
+	cloudStorageObjectDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/networkIpPoolDelete.go
+++ b/cmd/networkIpPoolDelete.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ var networkIpPoolDeleteCmd = &cobra.Command{
 An IP Pool is a range of nonintersecting, reusable IP addresses reserved to
 your account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		forceFlag, _ := cmd.Flags().GetBool("force")
 
 		// if force flag wasn't passed
@@ -67,8 +67,8 @@ your account.`,
 func init() {
 	networkIpPoolCmd.AddCommand(networkIpPoolDeleteCmd)
 
-	networkIpPoolDeleteCmd.Flags().String("uniq_id", "", "uniq_id of IP Pool")
+	networkIpPoolDeleteCmd.Flags().String("uniq-id", "", "uniq-id of IP Pool")
 	networkIpPoolDeleteCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
-	networkIpPoolDeleteCmd.MarkFlagRequired("uniq_id")
+	networkIpPoolDeleteCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/networkIpPoolDetails.go
+++ b/cmd/networkIpPoolDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -32,7 +32,7 @@ var networkIpPoolDetailsCmd = &cobra.Command{
 An IP Pool is a range of nonintersecting, reusable IP addresses reserved to
 your account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		freeOnlyFlag, _ := cmd.Flags().GetBool("free-only")
 
 		validateFields := map[interface{}]interface{}{
@@ -59,8 +59,8 @@ your account.`,
 func init() {
 	networkIpPoolCmd.AddCommand(networkIpPoolDetailsCmd)
 
-	networkIpPoolDetailsCmd.Flags().String("uniq_id", "", "uniq_id of IP Pool")
+	networkIpPoolDetailsCmd.Flags().String("uniq-id", "", "uniq-id of IP Pool")
 	networkIpPoolDetailsCmd.Flags().Bool("free-only", false, "return only unassigned IPs in the IP Pool")
 
-	networkIpPoolDetailsCmd.MarkFlagRequired("uniq_id")
+	networkIpPoolDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/networkIpPoolUpdate.go
+++ b/cmd/networkIpPoolUpdate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -35,7 +35,7 @@ var networkIpPoolUpdateCmd = &cobra.Command{
 An IP Pool is a range of nonintersecting, reusable IP addresses reserved to
 your account.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		newIpsFlag, _ := cmd.Flags().GetInt64("new-ips")
 
 		validateFields := map[interface{}]interface{}{
@@ -91,7 +91,7 @@ func init() {
 	networkIpPoolUpdateCmd.Flags().StringSliceVar(&networkIpPoolUpdateCmdAddIpsFlag, "add-ips",
 		[]string{}, "ips separated by ',' to add to IP Pool")
 	networkIpPoolUpdateCmd.Flags().Int64("new-ips", -1, "amount of new IPs to assign to the IP Pool")
-	networkIpPoolUpdateCmd.Flags().String("uniq_id", "", "uniq_id of IP Pool")
+	networkIpPoolUpdateCmd.Flags().String("uniq-id", "", "uniq-id of IP Pool")
 
-	networkIpPoolUpdateCmd.MarkFlagRequired("uniq_id")
+	networkIpPoolUpdateCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/networkLoadBalancerAddNode.go
+++ b/cmd/networkLoadBalancerAddNode.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -33,7 +33,7 @@ A node is an ip address. You can only add ip addresses that are assigned to
 your account.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		nodeFlag, _ := cmd.Flags().GetString("node")
 
 		validateFields := map[interface{}]interface{}{
@@ -61,8 +61,8 @@ your account.
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerAddNodeCmd)
-	networkLoadBalancerAddNodeCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
+	networkLoadBalancerAddNodeCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
 	networkLoadBalancerAddNodeCmd.Flags().String("node", "", "node (ip) to add to the Load Balancer")
-	networkLoadBalancerAddNodeCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerAddNodeCmd.MarkFlagRequired("uniq-id")
 	networkLoadBalancerAddNodeCmd.MarkFlagRequired("node")
 }

--- a/cmd/networkLoadBalancerAddService.go
+++ b/cmd/networkLoadBalancerAddService.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -31,7 +31,7 @@ var networkLoadBalancerAddServiceCmd = &cobra.Command{
 
 A service represents a service to load balance.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		srcPortFlag, _ := cmd.Flags().GetInt("src-port")
 		destPortFlag, _ := cmd.Flags().GetInt("dest-port")
 
@@ -62,11 +62,11 @@ A service represents a service to load balance.`,
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerAddServiceCmd)
-	networkLoadBalancerAddServiceCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
+	networkLoadBalancerAddServiceCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
 	networkLoadBalancerAddServiceCmd.Flags().Int("src-port", -1, "source port")
 	networkLoadBalancerAddServiceCmd.Flags().Int("dest-port", -1, "destination port")
 
-	networkLoadBalancerAddServiceCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerAddServiceCmd.MarkFlagRequired("uniq-id")
 	networkLoadBalancerAddServiceCmd.MarkFlagRequired("src-port")
 	networkLoadBalancerAddServiceCmd.MarkFlagRequired("dest-port")
 }

--- a/cmd/networkLoadBalancerDelete.go
+++ b/cmd/networkLoadBalancerDelete.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -30,7 +30,7 @@ var networkLoadBalancerDeleteCmd = &cobra.Command{
 	Short: "Delete a Load Balancer",
 	Long:  `Delete a Load Balancer.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		forceFlag, _ := cmd.Flags().GetBool("force")
 
 		// if force flag wasn't passed
@@ -64,8 +64,8 @@ var networkLoadBalancerDeleteCmd = &cobra.Command{
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerDeleteCmd)
-	networkLoadBalancerDeleteCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
+	networkLoadBalancerDeleteCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
 	networkLoadBalancerDeleteCmd.Flags().Bool("force", false, "bypass dialog confirmation")
 
-	networkLoadBalancerDeleteCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerDeleteCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/networkLoadBalancerDetails.go
+++ b/cmd/networkLoadBalancerDetails.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var networkLoadBalancerDetailsCmd = &cobra.Command{
 	Short: "Get details of a Load Balancer",
 	Long:  `Get details of a Load Balancer.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 
 		validateFields := map[interface{}]interface{}{
 			uniqIdFlag: "UniqId",
@@ -54,6 +54,6 @@ var networkLoadBalancerDetailsCmd = &cobra.Command{
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerDetailsCmd)
-	networkLoadBalancerDetailsCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
-	networkLoadBalancerDetailsCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerDetailsCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
+	networkLoadBalancerDetailsCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/networkLoadBalancerGetPossibleNodes.go
+++ b/cmd/networkLoadBalancerGetPossibleNodes.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,11 +29,11 @@ var networkLoadBalancerGetPossibleNodesCmd = &cobra.Command{
 	Short: "Get possible Load Balancer nodes",
 	Long: `Get possible nodes on the account.
 
-When --region_id is passed, it will only list possible Load Balancer nodes
+When --region-id is passed, it will only list possible Load Balancer nodes
 in that region.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		regionIdFlag, _ := cmd.Flags().GetInt("region_id")
+		regionIdFlag, _ := cmd.Flags().GetInt("region-id")
 
 		apiArgs := map[string]interface{}{}
 
@@ -59,6 +59,6 @@ in that region.
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerGetPossibleNodesCmd)
-	networkLoadBalancerGetPossibleNodesCmd.Flags().Int("region_id", -1,
+	networkLoadBalancerGetPossibleNodesCmd.Flags().Int("region-id", -1,
 		"when passed only shows possible Load Balancer nodes in this region")
 }

--- a/cmd/networkLoadBalancerRemoveNode.go
+++ b/cmd/networkLoadBalancerRemoveNode.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -29,7 +29,7 @@ var networkLoadBalancerRemoveNodeCmd = &cobra.Command{
 	Short: "Remove a node from an existing Load Balancer",
 	Long:  `Remove a node (ip) from an existing Load Balancer.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		nodeFlag, _ := cmd.Flags().GetString("node")
 
 		validateFields := map[interface{}]interface{}{
@@ -57,8 +57,8 @@ var networkLoadBalancerRemoveNodeCmd = &cobra.Command{
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerRemoveNodeCmd)
-	networkLoadBalancerRemoveNodeCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
+	networkLoadBalancerRemoveNodeCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
 	networkLoadBalancerRemoveNodeCmd.Flags().String("node", "", "node (ip) to remove from the Load Balancer")
-	networkLoadBalancerRemoveNodeCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerRemoveNodeCmd.MarkFlagRequired("uniq-id")
 	networkLoadBalancerRemoveNodeCmd.MarkFlagRequired("node")
 }

--- a/cmd/networkLoadBalancerRemoveService.go
+++ b/cmd/networkLoadBalancerRemoveService.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -31,7 +31,7 @@ var networkLoadBalancerRemoveServiceCmd = &cobra.Command{
 
 A service represents a service to load balance.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		srcPortFlag, _ := cmd.Flags().GetInt("src-port")
 
 		validateFields := map[interface{}]interface{}{
@@ -59,9 +59,9 @@ A service represents a service to load balance.`,
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerRemoveServiceCmd)
-	networkLoadBalancerRemoveServiceCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
+	networkLoadBalancerRemoveServiceCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
 	networkLoadBalancerRemoveServiceCmd.Flags().Int("src-port", -1,
 		"source port of service to remove from the Load Balancer")
-	networkLoadBalancerRemoveServiceCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerRemoveServiceCmd.MarkFlagRequired("uniq-id")
 	networkLoadBalancerRemoveServiceCmd.MarkFlagRequired("src-port")
 }

--- a/cmd/networkLoadBalancerUpdate.go
+++ b/cmd/networkLoadBalancerUpdate.go
@@ -25,8 +25,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
-	"github.com/liquidweb/liquidweb-cli/types/api"
-	"github.com/liquidweb/liquidweb-cli/types/cmd"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
+	cmdTypes "github.com/liquidweb/liquidweb-cli/types/cmd"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
 
@@ -94,12 +94,12 @@ A Load Balancer allows you to distribute traffic to multiple endpoints.
 To remove a health check from a service, simply call update for the service(s) omitting their --health-check entries. For example,
 this would remove any set health checks for services 443:443,80:80 (as well as remove any other services entirely):
 
-network load-balancer update --uniq_id ABC123 --services 443:443,80:80
+network load-balancer update --uniq-id ABC123 --services 443:443,80:80
 
 Similarly to remove a health check when using --health-check-file, simply remove the health check from the file.
 `, networkLoadBalancerServicesHealthChecksHelp, networkLoadBalancerServicesHealthCheckFileHelp),
 	Run: func(cmd *cobra.Command, args []string) {
-		uniqIdFlag, _ := cmd.Flags().GetString("uniq_id")
+		uniqIdFlag, _ := cmd.Flags().GetString("uniq-id")
 		nameFlag, _ := cmd.Flags().GetString("name")
 		strategyFlag, _ := cmd.Flags().GetString("strategy")
 		enableSslTerminationFlag, _ := cmd.Flags().GetBool("enable-ssl-termination")
@@ -294,7 +294,7 @@ Similarly to remove a health check when using --health-check-file, simply remove
 
 func init() {
 	networkLoadBalancerCmd.AddCommand(networkLoadBalancerUpdateCmd)
-	networkLoadBalancerUpdateCmd.Flags().String("uniq_id", "", "uniq_id of Load Balancer")
+	networkLoadBalancerUpdateCmd.Flags().String("uniq-id", "", "uniq-id of Load Balancer")
 	networkLoadBalancerUpdateCmd.Flags().String("strategy", "", "Load Balancer strategy (see 'network load-balancer get-strategies')")
 	networkLoadBalancerUpdateCmd.Flags().String("name", "", "name of Load Balancer")
 	networkLoadBalancerUpdateCmd.Flags().Bool("enable-ssl-termination", false, "enable ssl termination")
@@ -317,5 +317,5 @@ func init() {
 	networkLoadBalancerUpdateCmd.Flags().String("health-check-file", "",
 		"A file containing valid yaml describing the LoadBalancer health checks to add for the service(s). Should not be combined with --health-check.")
 
-	networkLoadBalancerUpdateCmd.MarkFlagRequired("uniq_id")
+	networkLoadBalancerUpdateCmd.MarkFlagRequired("uniq-id")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
-	"github.com/liquidweb/liquidweb-cli/types/api"
+	apiTypes "github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 )
 
@@ -121,7 +121,7 @@ func derivePrivateParentUniqId(name string) (string, error) {
 			privateParentUniqId = name
 		} else {
 			privateParentDetailsErr = fmt.Errorf(
-				"failed fetching parent details treating given --private-parent arg as a uniq_id [%s]: %s",
+				"failed fetching parent details treating given --private-parent arg as a uniq-id [%s]: %s",
 				name, err)
 		}
 	}
@@ -152,7 +152,7 @@ func derivePrivateParentUniqId(name string) (string, error) {
 					&privateParentDetails)
 				if err != nil {
 					privateParentDetailsErr = fmt.Errorf(
-						"failed fetching private parent details for discovered uniq_id [%s] error: %s %w",
+						"failed fetching private parent details for discovered uniq-id [%s] error: %s %w",
 						privateParentDetails.UniqId, err, privateParentDetailsErr)
 					return "", privateParentDetailsErr
 				}
@@ -163,7 +163,7 @@ func derivePrivateParentUniqId(name string) (string, error) {
 	}
 
 	if privateParentUniqId == "" {
-		return "", fmt.Errorf("failed deriving uniq_id of private parent from [%s]: %s", name, privateParentDetailsErr)
+		return "", fmt.Errorf("failed deriving uniq-id of private parent from [%s]: %s", name, privateParentDetailsErr)
 	}
 
 	return privateParentUniqId, nil


### PR DESCRIPTION
It's unusual to see an underscore in a cli flags, and there was some inconsistency in the same variable (i.e. image_id and image-id where used in different places).

All of the flags should use dashes now.  It was tricky to make sure not to replace things from or to api calls :)
