### PR TITLE
expand plan template variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The following functions are defined to be called from a plan template:
 
 - generatePassword <length>
 
-For example, to generate a 25 character password: 
+For example, to generate a random 25 character password: 
 
 ```password: "{{- generatePassword 25 -}}"```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cloud:
            bandwidth: "SS.5000"
 ```
 
-### Template Variables
+### Plan Variables
 
 Plan yaml can make use of golang's template variables.  Allow variables can be passed on the
 command line, it can use environment variables, and it can pull limited system information.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The following functions are defined to be called from a plan template:
 
 - generatePassword <length>
 
-For example: 
+For example, to generate a 25 character password: 
+
 ```password: "{{- generatePassword 25 -}}"```
 

--- a/README.md
+++ b/README.md
@@ -58,3 +58,77 @@ If you end up wanting to modify an auth context later on, you can do so with `au
 
 ## LiquidWeb Cloud
 The Cloud features you can use in manage.liquidweb.com on your Cloud Servers you can do with this command line tool. See `help cloud` for a full list of features and capabilities.
+
+## Plans
+
+A plan is a pre-defined yaml with optional template variables that can be used to
+repeate specific tasks.
+
+Currently only "lw cloud server create" is implemented.
+
+Example:
+
+`lw plan --file plan.yaml`
+
+```
+---
+cloud:
+   server:
+      create:
+         - type: "SS.VPS"
+           password: "{{- generatePassword 25 -}}"
+           template: "UBUNTU_1804_UNMANAGED"
+           zone: 40460
+           hostname: "web1.something.org"
+           ips: 1
+           public-ssh-key: "your public ssh key here
+           config-id: 88
+           backup-plan: "None"
+           bandwidth: "SS.5000"
+```
+
+### Template Variables
+
+Plan yaml can make use of golang's template variables.  Allow variables can be passed on the
+command line, it can use environment variables, and it can pull limited system information.
+
+#### Environment Variables
+Envonrment variables are defined as `.Env.VARNAME`.  On most linux systems and shells you can
+get the logged in user with `{{ .Env.USER }}`.
+
+#### User Defined Variables
+If you wanted to pass user defined variables on the command line you would use the `--var` flag
+(multiple `--var` flags can be passed).  For example, if you wanted to generate the hostname of
+`web3.somehost.org` you would use the following command and yaml:
+
+`lw plan --file play.yaml --var node=3 --var role=web`
+
+```
+    hostname: "{{- .Var.role -}}{{- .Var.node -}}.somehost.org"
+```
+
+#### System Information
+
+Limited system information is also available.  The folloing variables can be used:
+
+- .Sys.YYYY = Current Year
+- .Sys.MM = Current Month
+- .Sys.DD = Curent Date
+- .Sys.HH = Current Hour
+- .Sys.MI = Current Minute
+- .Sys.SS = Current Section
+
+For example:
+```
+    hostname: "web1.{{- .Sys.YYYY -}}{{- .Sys.MM -}}{{- .Sys.DD -}}.somehost.org"
+```
+
+#### Functions
+
+The following functions are defined to be called from a plan template:
+
+- generatePassword <length>
+
+For example: 
+```password: "{{- generatePassword 25 -}}"```
+

--- a/README.md
+++ b/README.md
@@ -133,3 +133,11 @@ For example, to generate a random 25 character password:
 
 ```password: "{{- generatePassword 25 -}}"```
 
+- now
+
+Gives access to a Golang `time` object set to the current time at invocation of the command.
+
+- hex
+
+Convert a number to hexidecimal.
+

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ cloud:
          - type: "SS.VPS"
            password: "{{- generatePassword 25 -}}"
            template: "UBUNTU_1804_UNMANAGED"
-           zone: 40460
-           hostname: "web1.something.org"
+           zone: 27
+           hostname: "web1.somehost.org"
            ips: 1
            public-ssh-key: "your public ssh key here
            config-id: 88
@@ -89,8 +89,8 @@ cloud:
 
 ### Plan Variables
 
-Plan yaml can make use of golang's template variables.  Allow variables can be passed on the
-command line, it can use environment variables, and it can pull limited system information.
+Plan yaml can make use of golang's template variables.  Allows variables to be passed on the
+command line and it can access environment variables.
 
 #### Environment Variables
 Envonrment variables are defined as `.Env.VARNAME`.  On most linux systems and shells you can
@@ -107,21 +107,6 @@ If you wanted to pass user defined variables on the command line you would use t
     hostname: "{{- .Var.role -}}{{- .Var.node -}}.somehost.org"
 ```
 
-#### System Information
-
-Limited system information is also available.  The folloing variables can be used:
-
-- .Sys.YYYY = Current Year
-- .Sys.MM = Current Month
-- .Sys.DD = Curent Date
-- .Sys.HH = Current Hour
-- .Sys.MI = Current Minute
-- .Sys.SS = Current Section
-
-For example:
-```
-    hostname: "web1.{{- .Sys.YYYY -}}{{- .Sys.MM -}}{{- .Sys.DD -}}.somehost.org"
-```
 
 #### Functions
 
@@ -135,7 +120,13 @@ For example, to generate a random 25 character password:
 
 - now
 
-Gives access to a Golang `time` object set to the current time at invocation of the command.
+Gives access to a Golang `time` object using your local machine's clock.
+
+Simple example:
+
+```
+    hostname: "web1.{{- now.Year -}}{{- now.Month -}}{{- now.Day -}}.somehost.org"
+```
 
 - hex
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -158,6 +158,10 @@ func processTemplate(varSliceFlag []string, planYaml []byte) ([]byte, error) {
 		"generatePassword": func(length int) string {
 			return utils.RandomString(length)
 		},
+		"now": time.Now,
+		"hex": func(number int64) string {
+			return fmt.Sprintf("%X", number)
+		},
 	}).
 		Parse(string(planYaml))
 	if err != nil {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -123,15 +124,32 @@ func varsToMap(vars []string) map[string]string {
 	return varMap
 }
 
+func systemVars() map[string]string {
+	sysMap := make(map[string]string)
+
+	currentTime := time.Now()
+
+	sysMap["YYYY"] = fmt.Sprintf("%0.4d", currentTime.Year())
+	sysMap["MM"] = fmt.Sprintf("%0.2d", currentTime.Month())
+	sysMap["DD"] = fmt.Sprintf("%0.2d", currentTime.Day())
+	sysMap["HH"] = fmt.Sprintf("%0.2d", currentTime.Hour())
+	sysMap["MM"] = fmt.Sprintf("%0.2d", currentTime.Minute())
+	sysMap["SS"] = fmt.Sprintf("%0.2d", currentTime.Second())
+
+	return sysMap
+}
+
 func processTemplate(varSliceFlag []string, planYaml []byte) ([]byte, error) {
 	type TemplateVars struct {
 		Var map[string]string
 		Env map[string]string
+		Sys map[string]string
 	}
 
 	tmplVars := &TemplateVars{
 		Var: varsToMap(varSliceFlag),
 		Env: envToMap(),
+		Sys: systemVars(),
 	}
 
 	var tmplBytes bytes.Buffer

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
+	"github.com/liquidweb/liquidweb-cli/utils"
 )
 
 var planCmd = &cobra.Command{
@@ -153,7 +154,12 @@ func processTemplate(varSliceFlag []string, planYaml []byte) ([]byte, error) {
 	}
 
 	var tmplBytes bytes.Buffer
-	tmpl, err := template.New("plan.yaml").Parse(string(planYaml))
+	tmpl, err := template.New("plan.yaml").Funcs(template.FuncMap{
+		"generatePassword": func(length int) string {
+			return utils.RandomString(length)
+		},
+	}).
+		Parse(string(planYaml))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -134,7 +134,7 @@ func systemVars() map[string]string {
 	sysMap["MM"] = fmt.Sprintf("%0.2d", currentTime.Month())
 	sysMap["DD"] = fmt.Sprintf("%0.2d", currentTime.Day())
 	sysMap["HH"] = fmt.Sprintf("%0.2d", currentTime.Hour())
-	sysMap["MM"] = fmt.Sprintf("%0.2d", currentTime.Minute())
+	sysMap["MI"] = fmt.Sprintf("%0.2d", currentTime.Minute())
 	sysMap["SS"] = fmt.Sprintf("%0.2d", currentTime.Second())
 
 	return sysMap

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -125,32 +125,15 @@ func varsToMap(vars []string) map[string]string {
 	return varMap
 }
 
-func systemVars() map[string]string {
-	sysMap := make(map[string]string)
-
-	currentTime := time.Now()
-
-	sysMap["YYYY"] = fmt.Sprintf("%0.4d", currentTime.Year())
-	sysMap["MM"] = fmt.Sprintf("%0.2d", currentTime.Month())
-	sysMap["DD"] = fmt.Sprintf("%0.2d", currentTime.Day())
-	sysMap["HH"] = fmt.Sprintf("%0.2d", currentTime.Hour())
-	sysMap["MI"] = fmt.Sprintf("%0.2d", currentTime.Minute())
-	sysMap["SS"] = fmt.Sprintf("%0.2d", currentTime.Second())
-
-	return sysMap
-}
-
 func processTemplate(varSliceFlag []string, planYaml []byte) ([]byte, error) {
 	type TemplateVars struct {
 		Var map[string]string
 		Env map[string]string
-		Sys map[string]string
 	}
 
 	tmplVars := &TemplateVars{
 		Var: varsToMap(varSliceFlag),
 		Env: envToMap(),
-		Sys: systemVars(),
 	}
 
 	var tmplBytes bytes.Buffer


### PR DESCRIPTION
added functions:

- generatePassword
- now
- hex

specifically I wanted to be able to do things like this in my yaml

```
password: "{{- generatePassword 25 -}}"
hostname: "release-test.{{- hex now.Unix -}}.addictmud.org"
```