### PR TITLE
force context names to lowercase

### DIFF
--- a/cmd/authAddContext.go
+++ b/cmd/authAddContext.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -37,6 +38,10 @@ Use this if you've already setup contexts with "auth init".`,
 		url, _ := cmd.Flags().GetString("api-url")
 		insecure, _ := cmd.Flags().GetBool("insecure")
 		timeout, _ := cmd.Flags().GetInt("timeout")
+
+		if strings.ToLower(contextName) != contextName {
+			lwCliInst.Die(fmt.Errorf("context names must be lowercase"))
+		}
 
 		file, err := getExpectedConfigPath()
 		if err != nil {

--- a/cmd/authInit.go
+++ b/cmd/authInit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -160,6 +161,11 @@ func fetchAuthDataInteractively() (writeConfig bool, err error) {
 					break WHILEMOREADDS
 				} else if contextNameAnswer == "" {
 					if _, err := term.Write([]byte("context name cannot be blank.\n")); err != nil {
+						userInputError <- err
+						break WHILEMOREADDS
+					}
+				} else if strings.ToLower(contextNameAnswer) != contextNameAnswer {
+					if _, err := term.Write([]byte("context name cannot be uppercase.\n")); err != nil {
 						userInputError <- err
 						break WHILEMOREADDS
 					}


### PR DESCRIPTION
https://github.com/spf13/viper/issues/411

fixes an issue reported by @jvandellen  where contexts created with uppercase characters cannot later be modified, because viper converts the user inputted context name to lowercase, causing matching on the key from the config to not match.

```
~ ❯ lw auth get-contexts                                                                                                           ⏎
Context: HelpfulH2
	Username: helpfulh2
	API URL: https://api.liquidweb.com
	Insecure: false
	Timeout: 90
Context: HelpfulH
	Username: helpfulh
	API URL: https://api.liquidweb.com
	Insecure: false
	Timeout: 90
Current context: [HelpfulH2]
~ ❯ lw auth update-context --context HelpfulH2 --username derp --password derp
A fatal error has occurred:
context with name [HelpfulH2] doesnt exist
```