### PR TITLE
cast to int, a float64 of value 1 will cast to bool false

### DIFF
--- a/cmd/cloudTemplateList.go
+++ b/cmd/cloudTemplateList.go
@@ -67,7 +67,7 @@ var cloudTemplateListCmd = &cobra.Command{
 		}
 
 		for _, template := range templateList.Items {
-			if cast.ToBool(template["deprecated"]) {
+			if cast.ToBool(cast.ToInt(template["deprecated"])) {
 				continue
 			}
 


### PR DESCRIPTION
this value when it comes out of the interface is a float64, and a float64 gets casted to false. Example below demonstrates the issue solved in this PR.

```golang
package main

import (
        "fmt"
        "github.com/spf13/cast"
)

func main() {
        template := map[string]interface{}{
                "deprecated": float64(1),
        }
        fmt.Printf("its %t\n", cast.ToBool(template["deprecated"]))
}
```
```shell
go run ../x.go
its false
```