### PR TITLE
allow resizing to a pp with same specs as old non pp config

### DIFF
--- a/cmd/cloudServerResize.go
+++ b/cmd/cloudServerResize.go
@@ -178,9 +178,12 @@ During all resizes, the Cloud Server is online as the disk synchronizes.
 					memoryChanging = true
 				}
 			}
-			if !diskspaceChanging && !vcpuChanging && !memoryChanging {
-				lwCliInst.Die(fmt.Errorf(
-					"private parent resize, but passed diskspace, memory, vcpu values match existing values"))
+			// allow resizes to a private parent even if its old non private parent config had exact same specs
+			if cloudServerDetails.ConfigId == 0 && cloudServerDetails.PrivateParent != privateParentUniqId {
+				if !diskspaceChanging && !vcpuChanging && !memoryChanging {
+					lwCliInst.Die(fmt.Errorf(
+						"private parent resize, but passed diskspace, memory, vcpu values match existing values"))
+				}
 			}
 
 			resizeArgs["newsize"] = 0                  // 0 indicates private parent resize


### PR DESCRIPTION
previously if you attempted to move from a normal config to a private parent.. but with the same specs as the config you are leaving.. it would error out:

```
A fatal error has occurred:                                                                                                                                                                                                                    
                                                                                                                                                                                                                                               
private parent resize, but passed diskspace, memory, vcpu values match existing values                                                                                                                                                         
```

this fixes it to dtrt