### PR TITLE
#39/#40 and ease `zone` param restriction if private-parent was passed

### DIFF
--- a/cmd/cloudNetworkPublicList.go
+++ b/cmd/cloudNetworkPublicList.go
@@ -17,7 +17,9 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
@@ -48,6 +50,7 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 
 		fmt.Printf("IP Assignments for %s:\n\n", uniqIdFlag)
 
+		_, cloudPrivateSubnet, _ := net.ParseCIDR("10.0.0.0/8")
 		for c, item := range results.Items {
 			var details apiTypes.NetworkAssignmentListEntry
 			if err := instance.CastFieldTypes(item, &details); err != nil {
@@ -58,7 +61,11 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 			if c == 0 {
 				fmt.Println("Primary IP:")
 			} else {
-				fmt.Println("Secondary IP:")
+				if cloudPrivateSubnet.Contains(net.ParseIP(cast.ToString(item["ip"]))) {
+					fmt.Println("Private/Secondary IP:")
+				} else {
+					fmt.Println("Secondary IP:")
+				}
 			}
 			fmt.Print(details)
 		}

--- a/cmd/cloudNetworkPublicList.go
+++ b/cmd/cloudNetworkPublicList.go
@@ -17,9 +17,7 @@ package cmd
 
 import (
 	"fmt"
-	"net"
 
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
@@ -50,7 +48,12 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 
 		fmt.Printf("IP Assignments for %s:\n\n", uniqIdFlag)
 
-		_, cloudPrivateSubnet, _ := net.ParseCIDR("10.0.0.0/8")
+		var private apiTypes.CloudNetworkPrivateGetIpResponse
+		privateArgs := map[string]interface{}{"uniq_id": uniqIdFlag}
+		if err := lwCliInst.CallLwApiInto("bleed/network/private/getip", privateArgs, &private); err != nil {
+			lwCliInst.Die(err)
+		}
+
 		for c, item := range results.Items {
 			var details apiTypes.NetworkAssignmentListEntry
 			if err := instance.CastFieldTypes(item, &details); err != nil {
@@ -61,8 +64,8 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 			if c == 0 {
 				fmt.Println("Primary IP:")
 			} else {
-				if cloudPrivateSubnet.Contains(net.ParseIP(cast.ToString(item["ip"]))) {
-					fmt.Println("Private/Secondary IP:")
+				if details.Ip == private.Ip {
+					fmt.Println("Private Network IP:")
 				} else {
 					fmt.Println("Secondary IP:")
 				}

--- a/cmd/cloudNetworkPublicList.go
+++ b/cmd/cloudNetworkPublicList.go
@@ -46,14 +46,20 @@ var cloudNetworkPublicListCmd = &cobra.Command{
 			lwCliInst.Die(err)
 		}
 
-		fmt.Printf("IP Assignments for %s:\n", uniqIdFlag)
+		fmt.Printf("IP Assignments for %s:\n\n", uniqIdFlag)
 
-		for _, item := range results.Items {
+		for c, item := range results.Items {
 			var details apiTypes.NetworkAssignmentListEntry
 			if err := instance.CastFieldTypes(item, &details); err != nil {
 				lwCliInst.Die(err)
 			}
 
+			// first ip is always primary
+			if c == 0 {
+				fmt.Println("Primary IP:")
+			} else {
+				fmt.Println("Secondary IP:")
+			}
 			fmt.Print(details)
 		}
 	},

--- a/cmd/cloudPrivateParentDelete.go
+++ b/cmd/cloudPrivateParentDelete.go
@@ -47,7 +47,7 @@ as well as how many resources each Cloud Server gets.`,
 
 		// if passed a private-parent flag, derive its uniq_id
 		var privateParentUniqId string
-		privateParentUniqId, err := lwCliInst.DerivePrivateParentUniqId(nameFlag)
+		privateParentUniqId, _, err := lwCliInst.DerivePrivateParentUniqId(nameFlag)
 		if err != nil {
 			lwCliInst.Die(err)
 		}

--- a/cmd/cloudPrivateParentDetails.go
+++ b/cmd/cloudPrivateParentDetails.go
@@ -37,7 +37,7 @@ as well as how many resources each Cloud Server gets.`,
 
 		// if passed a private-parent flag, derive its uniq_id
 		var privateParentUniqId string
-		privateParentUniqId, err := lwCliInst.DerivePrivateParentUniqId(nameFlag)
+		privateParentUniqId, _, err := lwCliInst.DerivePrivateParentUniqId(nameFlag)
 		if err != nil {
 			lwCliInst.Die(err)
 		}

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -73,10 +73,16 @@ Server is not on a Private Parent.`,
 
 		var privateParentUniqId string
 		if privateParentFlag != "" {
-			var err error
-			privateParentUniqId, err = lwCliInst.DerivePrivateParentUniqId(privateParentFlag)
+			var (
+				err  error
+				zone int64
+			)
+			privateParentUniqId, zone, err = lwCliInst.DerivePrivateParentUniqId(privateParentFlag)
 			if err != nil {
 				lwCliInst.Die(err)
+			}
+			if zoneFlag == -1 {
+				zoneFlag = zone
 			}
 		}
 

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -68,7 +68,7 @@ For a list of backups, see 'cloud backups list'
 		params.BackupDays, _ = cmd.Flags().GetInt("backup-days")
 		params.BackupQuota, _ = cmd.Flags().GetInt("backup-quota")
 		params.Bandwidth, _ = cmd.Flags().GetString("bandwidth")
-		params.Zone, _ = cmd.Flags().GetInt("zone")
+		params.Zone, _ = cmd.Flags().GetInt64("zone")
 		params.WinAv, _ = cmd.Flags().GetString("winav")
 		params.MsSql, _ = cmd.Flags().GetString("ms-sql")
 		params.PrivateParent, _ = cmd.Flags().GetString("private-parent")
@@ -114,7 +114,7 @@ func init() {
 	cloudServerCreateCmd.Flags().Int("backup-days", -1, "Enable daily backup plan. This is the amount of days to keep a backup")
 	cloudServerCreateCmd.Flags().Int("backup-quota", -1, "Enable quota backup plan. This is the total amount of GB to keep.")
 	cloudServerCreateCmd.Flags().String("bandwidth", "SS.10000", "bandwidth package to use")
-	cloudServerCreateCmd.Flags().Int("zone", 0, "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
+	cloudServerCreateCmd.Flags().Int64("zone", 0, "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
 	cloudServerCreateCmd.Flags().String("password", "", "root or administrator password to set")
 
 	cloudServerCreateCmd.Flags().Int("backup-id", -1, "id of cloud backup to create from (see 'cloud backup list')")
@@ -133,8 +133,4 @@ func init() {
 	// windows specific
 	cloudServerCreateCmd.Flags().String("winav", "", "Use only with Windows Servers. Typically (None or NOD32) for value when set")
 	cloudServerCreateCmd.Flags().String("ms-sql", "", "Microsoft SQL Server")
-
-	if err := cloudServerCreateCmd.MarkFlagRequired("zone"); err != nil {
-		lwCliInst.Die(err)
-	}
 }

--- a/instance/cloudServerResize.go
+++ b/instance/cloudServerResize.go
@@ -136,7 +136,7 @@ func (self *Client) CloudServerResize(params *CloudServerResizeParams) (result s
 		}
 
 		var privateParentUniqId string
-		privateParentUniqId, err = self.DerivePrivateParentUniqId(params.PrivateParent)
+		privateParentUniqId, _, err = self.DerivePrivateParentUniqId(params.PrivateParent)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
implements:

https://github.com/liquidweb/liquidweb-cli/issues/39
https://github.com/liquidweb/liquidweb-cli/issues/47

Also now derives zone in derive private parent uniq id helper. Saves some time not having to always pass `--zone` on args to `cloud server create` for example if you gave a `--private-parent` already.