### PR TITLE
Introduce default flags #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ Usage:
   lw [command]
 
 Available Commands:
-  asset       All things assets
-  auth        authentication actions
-  cloud       Interact with LiquidWeb's Cloud platform
-  completion  Generate completion script
-  dedicated   All things dedicated server
-  help        Help about any command
-  network     network actions
-  plan        Process YAML plan file
-  ssh         SSH to a Server
-  version     show build information
+  asset         All things assets
+  auth          authentication actions
+  cloud         Interact with LiquidWeb's Cloud platform
+  completion    Generate completion script
+  dedicated     All things dedicated server
+  default-flags Manage default flags
+  help          Help about any command
+  network       network actions
+  plan          Process YAML plan file
+  ssh           SSH to a Server
+  version       show build information
 
 Flags:
       --config string        config file (default is $HOME/.liquidweb-cli.yaml)

--- a/cmd/cloudNetworkVipCreate.go
+++ b/cmd/cloudNetworkVipCreate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
@@ -95,6 +94,6 @@ func init() {
 	cloudNetworkVipCmd.AddCommand(cloudNetworkVipCreateCmd)
 	cloudNetworkVipCreateCmd.Flags().String("name", fmt.Sprintf("vip-%s", utils.RandomString(8)),
 		"name for the new VIP")
-	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")),
+	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")),
 		"zone id to create VIP in (see: 'cloud server options --zones')")
 }

--- a/cmd/cloudNetworkVipCreate.go
+++ b/cmd/cloudNetworkVipCreate.go
@@ -94,6 +94,6 @@ func init() {
 	cloudNetworkVipCmd.AddCommand(cloudNetworkVipCreateCmd)
 	cloudNetworkVipCreateCmd.Flags().String("name", fmt.Sprintf("vip-%s", utils.RandomString(8)),
 		"name for the new VIP")
-	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")),
+	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
 		"zone id to create VIP in (see: 'cloud server options --zones')")
 }

--- a/cmd/cloudNetworkVipCreate.go
+++ b/cmd/cloudNetworkVipCreate.go
@@ -94,6 +94,6 @@ func init() {
 	cloudNetworkVipCmd.AddCommand(cloudNetworkVipCreateCmd)
 	cloudNetworkVipCreateCmd.Flags().String("name", fmt.Sprintf("vip-%s", utils.RandomString(8)),
 		"name for the new VIP")
-	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
+	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("cloud_network_vip_create_zone", -1)),
 		"zone id to create VIP in (see: 'cloud server options --zones')")
 }

--- a/cmd/cloudNetworkVipCreate.go
+++ b/cmd/cloudNetworkVipCreate.go
@@ -18,8 +18,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/utils"
 	"github.com/liquidweb/liquidweb-cli/validate"
@@ -93,10 +95,6 @@ func init() {
 	cloudNetworkVipCmd.AddCommand(cloudNetworkVipCreateCmd)
 	cloudNetworkVipCreateCmd.Flags().String("name", fmt.Sprintf("vip-%s", utils.RandomString(8)),
 		"name for the new VIP")
-	cloudNetworkVipCreateCmd.Flags().Int64("zone", -1,
+	cloudNetworkVipCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")),
 		"zone id to create VIP in (see: 'cloud server options --zones')")
-
-	if err := cloudNetworkVipCreateCmd.MarkFlagRequired("zone"); err != nil {
-		lwCliInst.Die(err)
-	}
 }

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -70,12 +70,12 @@ of configs, check 'cloud server options --configs'.`,
 func init() {
 	cloudPrivateParentCmd.AddCommand(cloudPrivateParentCreateCmd)
 
-	cloudPrivateParentCreateCmd.Flags().Int64("config-id", -1, "config-id (category must be bare-metal or bare-metal-r)")
+	cloudPrivateParentCreateCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("config-id", -1)), "config-id (category must be bare-metal or bare-metal-r)")
 	cloudPrivateParentCreateCmd.Flags().String("name", "", "name for your Private Parent")
 	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
 		"id number of the zone to provision the Private Parent in ('cloud server options --zones')")
 
-	reqs := []string{"config-id", "name"}
+	reqs := []string{"name"}
 	for _, req := range reqs {
 		if err := cloudPrivateParentCreateCmd.MarkFlagRequired(req); err != nil {
 			lwCliInst.Die(err)

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -70,9 +70,9 @@ of configs, check 'cloud server options --configs'.`,
 func init() {
 	cloudPrivateParentCmd.AddCommand(cloudPrivateParentCreateCmd)
 
-	cloudPrivateParentCreateCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("config-id", -1)), "config-id (category must be bare-metal or bare-metal-r)")
+	cloudPrivateParentCreateCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("cloud_private-parent_create_config-id", -1)), "config-id (category must be bare-metal or bare-metal-r)")
 	cloudPrivateParentCreateCmd.Flags().String("name", "", "name for your Private Parent")
-	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
+	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("cloud_private-parent_create_zone", -1)),
 		"id number of the zone to provision the Private Parent in ('cloud server options --zones')")
 
 	reqs := []string{"name"}

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -72,7 +72,7 @@ func init() {
 
 	cloudPrivateParentCreateCmd.Flags().Int64("config-id", -1, "config-id (category must be bare-metal or bare-metal-r)")
 	cloudPrivateParentCreateCmd.Flags().String("name", "", "name for your Private Parent")
-	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")),
+	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
 		"id number of the zone to provision the Private Parent in ('cloud server options --zones')")
 
 	reqs := []string{"config-id", "name"}

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -73,7 +72,7 @@ func init() {
 
 	cloudPrivateParentCreateCmd.Flags().Int64("config-id", -1, "config-id (category must be bare-metal or bare-metal-r)")
 	cloudPrivateParentCreateCmd.Flags().String("name", "", "name for your Private Parent")
-	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")),
+	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")),
 		"id number of the zone to provision the Private Parent in ('cloud server options --zones')")
 
 	reqs := []string{"config-id", "name"}

--- a/cmd/cloudPrivateParentCreate.go
+++ b/cmd/cloudPrivateParentCreate.go
@@ -18,8 +18,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -71,15 +73,13 @@ func init() {
 
 	cloudPrivateParentCreateCmd.Flags().Int64("config-id", -1, "config-id (category must be bare-metal or bare-metal-r)")
 	cloudPrivateParentCreateCmd.Flags().String("name", "", "name for your Private Parent")
-	cloudPrivateParentCreateCmd.Flags().Int64("zone", -1, "id number of the zone to provision the Private Parent in ('cloud server options --zones')")
+	cloudPrivateParentCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")),
+		"id number of the zone to provision the Private Parent in ('cloud server options --zones')")
 
-	if err := cloudPrivateParentCreateCmd.MarkFlagRequired("config-id"); err != nil {
-		lwCliInst.Die(err)
-	}
-	if err := cloudPrivateParentCreateCmd.MarkFlagRequired("zone"); err != nil {
-		lwCliInst.Die(err)
-	}
-	if err := cloudPrivateParentCreateCmd.MarkFlagRequired("name"); err != nil {
-		lwCliInst.Die(err)
+	reqs := []string{"config-id", "name"}
+	for _, req := range reqs {
+		if err := cloudPrivateParentCreateCmd.MarkFlagRequired(req); err != nil {
+			lwCliInst.Die(err)
+		}
 	}
 }

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -65,9 +65,6 @@ Server is not on a Private Parent.`,
 			hostnameFlag: map[string]string{"type": "NonEmptyString", "optional": "false"},
 		}
 
-		if privateParentFlag != "" && configIdFlag != -1 {
-			lwCliInst.Die(fmt.Errorf("cant pass both --config-id and --private-parent flags"))
-		}
 		if privateParentFlag == "" && configIdFlag == -1 {
 			lwCliInst.Die(fmt.Errorf("must pass --config-id or --private-parent"))
 		}
@@ -115,7 +112,7 @@ Server is not on a Private Parent.`,
 			cloneArgs["vcpu"] = vcpuFlag
 			validateFields[vcpuFlag] = "PositiveInt64"
 		}
-		if configIdFlag != -1 {
+		if configIdFlag != -1 && privateParentFlag == "" {
 			cloneArgs["config_id"] = configIdFlag
 			validateFields[configIdFlag] = "PositiveInt64"
 		}

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/types/api"
@@ -162,7 +163,7 @@ func init() {
 	cloudServerCloneCmd.Flags().Int64("vcpu", -1, "amount of vcpus for new Cloud Server (when private-parent)")
 
 	// Non Private Parent
-	cloudServerCloneCmd.Flags().Int64("config-id", -1,
+	cloudServerCloneCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("config-id", -1)),
 		"config-id for new Cloud Server (when !private-parent) (see: 'cloud server options --configs')")
 
 	if err := cloudServerCloneCmd.MarkFlagRequired("uniq-id"); err != nil {

--- a/cmd/cloudServerClone.go
+++ b/cmd/cloudServerClone.go
@@ -160,7 +160,7 @@ func init() {
 	cloudServerCloneCmd.Flags().Int64("vcpu", -1, "amount of vcpus for new Cloud Server (when private-parent)")
 
 	// Non Private Parent
-	cloudServerCloneCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("config-id", -1)),
+	cloudServerCloneCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("cloud_server_clone_config-id", -1)),
 		"config-id for new Cloud Server (when !private-parent) (see: 'cloud server options --configs')")
 
 	if err := cloudServerCloneCmd.MarkFlagRequired("uniq-id"); err != nil {

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/instance"
 )
 
@@ -134,7 +135,7 @@ func init() {
 		sshPubKeyFile = fmt.Sprintf("%s/.ssh/id_rsa.pub", home)
 	}
 
-	cloudServerCreateCmd.Flags().String("template", "", "template to use (see 'cloud server options --templates')")
+	cloudServerCreateCmd.Flags().String("template", cast.ToString(defaults.GetOrNag("template")), "template to use (see 'cloud server options --templates')")
 	cloudServerCreateCmd.Flags().String("type", "SS.VPS", "some examples of types; SS.VPS, SS.VPS.WIN, SS.VM, SS.VM.WIN")
 	cloudServerCreateCmd.Flags().String("hostname", "", "hostname to set")
 	cloudServerCreateCmd.Flags().Int("ips", 1, "amount of IP addresses")
@@ -144,7 +145,7 @@ func init() {
 	cloudServerCreateCmd.Flags().Int("backup-days", -1, "Enable daily backup plan. This is the amount of days to keep a backup")
 	cloudServerCreateCmd.Flags().Int("backup-quota", -1, "Enable quota backup plan. This is the total amount of GB to keep.")
 	cloudServerCreateCmd.Flags().String("bandwidth", "SS.10000", "bandwidth package to use")
-	cloudServerCreateCmd.Flags().Int64("zone", 0, "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
+	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
 	cloudServerCreateCmd.Flags().String("password", "", "root or administrator password to set")
 
 	cloudServerCreateCmd.Flags().Int("backup-id", -1, "id of cloud backup to create from (see 'cloud backup list')")

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/flags/defaults"
+	"github.com/liquidweb/liquidweb-cli/config"
 	"github.com/liquidweb/liquidweb-cli/instance"
 )
 
@@ -88,6 +88,7 @@ cloud:
 lw plan --file /tmp/cloud.server.create.yaml
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("config.CurrentContext is now: %s\n", config.CurrentContext)
 		params := &instance.CloudServerCreateParams{}
 
 		params.Template, _ = cmd.Flags().GetString("template")
@@ -135,7 +136,7 @@ func init() {
 		sshPubKeyFile = fmt.Sprintf("%s/.ssh/id_rsa.pub", home)
 	}
 
-	cloudServerCreateCmd.Flags().String("template", cast.ToString(defaults.GetOrNag("template")), "template to use (see 'cloud server options --templates')")
+	cloudServerCreateCmd.Flags().String("template", cast.ToString(defaultFlag("template")), "template to use (see 'cloud server options --templates')")
 	cloudServerCreateCmd.Flags().String("type", "SS.VPS", "some examples of types; SS.VPS, SS.VPS.WIN, SS.VM, SS.VM.WIN")
 	cloudServerCreateCmd.Flags().String("hostname", "", "hostname to set")
 	cloudServerCreateCmd.Flags().Int("ips", 1, "amount of IP addresses")
@@ -145,7 +146,7 @@ func init() {
 	cloudServerCreateCmd.Flags().Int("backup-days", -1, "Enable daily backup plan. This is the amount of days to keep a backup")
 	cloudServerCreateCmd.Flags().Int("backup-quota", -1, "Enable quota backup plan. This is the total amount of GB to keep.")
 	cloudServerCreateCmd.Flags().String("bandwidth", "SS.10000", "bandwidth package to use")
-	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
+	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
 	cloudServerCreateCmd.Flags().String("password", "", "root or administrator password to set")
 
 	cloudServerCreateCmd.Flags().Int("backup-id", -1, "id of cloud backup to create from (see 'cloud backup list')")

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/config"
 	"github.com/liquidweb/liquidweb-cli/instance"
 )
 

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -134,17 +134,17 @@ func init() {
 		sshPubKeyFile = fmt.Sprintf("%s/.ssh/id_rsa.pub", home)
 	}
 
-	cloudServerCreateCmd.Flags().String("template", cast.ToString(defaultFlag("template")), "template to use (see 'cloud server options --templates')")
+	cloudServerCreateCmd.Flags().String("template", cast.ToString(defaultFlag("cloud_server_create_template")), "template to use (see 'cloud server options --templates')")
 	cloudServerCreateCmd.Flags().String("type", "SS.VPS", "some examples of types; SS.VPS, SS.VPS.WIN, SS.VM, SS.VM.WIN")
 	cloudServerCreateCmd.Flags().String("hostname", "", "hostname to set")
 	cloudServerCreateCmd.Flags().Int("ips", 1, "amount of IP addresses")
 	cloudServerCreateCmd.Flags().String("public-ssh-key", sshPubKeyFile,
 		"path to file containing the public ssh key you wish to be on the new Cloud Server")
-	cloudServerCreateCmd.Flags().Int("config-id", cast.ToInt(defaultFlag("config-id", -1)), "config-id to use")
+	cloudServerCreateCmd.Flags().Int("config-id", cast.ToInt(defaultFlag("cloud_server_create_config-id", -1)), "config-id to use")
 	cloudServerCreateCmd.Flags().Int("backup-days", -1, "Enable daily backup plan. This is the amount of days to keep a backup")
 	cloudServerCreateCmd.Flags().Int("backup-quota", -1, "Enable quota backup plan. This is the total amount of GB to keep.")
 	cloudServerCreateCmd.Flags().String("bandwidth", "SS.10000", "bandwidth package to use")
-	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
+	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("cloud_server_create_zone", -1)), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
 	cloudServerCreateCmd.Flags().String("password", "", "root or administrator password to set")
 
 	cloudServerCreateCmd.Flags().Int("backup-id", -1, "id of cloud backup to create from (see 'cloud backup list')")

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -140,11 +140,11 @@ func init() {
 	cloudServerCreateCmd.Flags().Int("ips", 1, "amount of IP addresses")
 	cloudServerCreateCmd.Flags().String("public-ssh-key", sshPubKeyFile,
 		"path to file containing the public ssh key you wish to be on the new Cloud Server")
-	cloudServerCreateCmd.Flags().Int("config-id", 0, "config-id to use")
+	cloudServerCreateCmd.Flags().Int("config-id", cast.ToInt(defaultFlag("config-id", -1)), "config-id to use")
 	cloudServerCreateCmd.Flags().Int("backup-days", -1, "Enable daily backup plan. This is the amount of days to keep a backup")
 	cloudServerCreateCmd.Flags().Int("backup-quota", -1, "Enable quota backup plan. This is the total amount of GB to keep.")
 	cloudServerCreateCmd.Flags().String("bandwidth", "SS.10000", "bandwidth package to use")
-	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
+	cloudServerCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)), "zone (id) to create new Cloud Server in (see 'cloud server options --zones')")
 	cloudServerCreateCmd.Flags().String("password", "", "root or administrator password to set")
 
 	cloudServerCreateCmd.Flags().Int("backup-id", -1, "id of cloud backup to create from (see 'cloud backup list')")

--- a/cmd/cloudServerCreate.go
+++ b/cmd/cloudServerCreate.go
@@ -88,7 +88,6 @@ cloud:
 lw plan --file /tmp/cloud.server.create.yaml
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("config.CurrentContext is now: %s\n", config.CurrentContext)
 		params := &instance.CloudServerCreateParams{}
 
 		params.Template, _ = cmd.Flags().GetString("template")

--- a/cmd/cloudServerResize.go
+++ b/cmd/cloudServerResize.go
@@ -105,7 +105,7 @@ func init() {
 	cloudServerResizeCmd.Flags().Int64("memory", -1, "desired memory (when private-parent)")
 	cloudServerResizeCmd.Flags().Bool("skip-fs-resize", false, "whether or not to skip the fs resize")
 	cloudServerResizeCmd.Flags().Int64("vcpu", -1, "desired vcpu count (when private-parent)")
-	cloudServerResizeCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("config-id", -1)),
+	cloudServerResizeCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("cloud_server_resize_config-id", -1)),
 		"config-id of your desired config (when !private-parent) (see 'cloud server options --configs')")
 
 	if err := cloudServerResizeCmd.MarkFlagRequired("uniq-id"); err != nil {

--- a/cmd/cloudServerResize.go
+++ b/cmd/cloudServerResize.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
 	"github.com/liquidweb/liquidweb-cli/instance"
@@ -104,7 +105,7 @@ func init() {
 	cloudServerResizeCmd.Flags().Int64("memory", -1, "desired memory (when private-parent)")
 	cloudServerResizeCmd.Flags().Bool("skip-fs-resize", false, "whether or not to skip the fs resize")
 	cloudServerResizeCmd.Flags().Int64("vcpu", -1, "desired vcpu count (when private-parent)")
-	cloudServerResizeCmd.Flags().Int64("config-id", -1,
+	cloudServerResizeCmd.Flags().Int64("config-id", cast.ToInt64(defaultFlag("config-id", -1)),
 		"config-id of your desired config (when !private-parent) (see 'cloud server options --configs')")
 
 	if err := cloudServerResizeCmd.MarkFlagRequired("uniq-id"); err != nil {

--- a/cmd/cloudTemplateRestore.go
+++ b/cmd/cloudTemplateRestore.go
@@ -60,7 +60,7 @@ func init() {
 	cloudTemplateCmd.AddCommand(cloudTemplateRestoreCmd)
 
 	cloudTemplateRestoreCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
-	cloudTemplateRestoreCmd.Flags().String("template", cast.ToString(defaultFlag("template")), "name of template to restore")
+	cloudTemplateRestoreCmd.Flags().String("template", cast.ToString(defaultFlag("cloud_template_restore_template")), "name of template to restore")
 
 	if err := cloudTemplateRestoreCmd.MarkFlagRequired("uniq-id"); err != nil {
 		lwCliInst.Die(err)

--- a/cmd/cloudTemplateRestore.go
+++ b/cmd/cloudTemplateRestore.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/instance"
 )
 
@@ -61,7 +60,7 @@ func init() {
 	cloudTemplateCmd.AddCommand(cloudTemplateRestoreCmd)
 
 	cloudTemplateRestoreCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
-	cloudTemplateRestoreCmd.Flags().String("template", cast.ToString(defaults.GetOrNag("template")), "name of template to restore")
+	cloudTemplateRestoreCmd.Flags().String("template", cast.ToString(defaultFlag("template")), "name of template to restore")
 
 	if err := cloudTemplateRestoreCmd.MarkFlagRequired("uniq-id"); err != nil {
 		lwCliInst.Die(err)

--- a/cmd/cloudTemplateRestore.go
+++ b/cmd/cloudTemplateRestore.go
@@ -18,8 +18,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/instance"
 )
 
@@ -59,12 +61,9 @@ func init() {
 	cloudTemplateCmd.AddCommand(cloudTemplateRestoreCmd)
 
 	cloudTemplateRestoreCmd.Flags().String("uniq-id", "", "uniq-id of Cloud Server")
-	cloudTemplateRestoreCmd.Flags().String("template", "", "name of template to restore")
+	cloudTemplateRestoreCmd.Flags().String("template", cast.ToString(defaults.GetOrNag("template")), "name of template to restore")
 
 	if err := cloudTemplateRestoreCmd.MarkFlagRequired("uniq-id"); err != nil {
-		lwCliInst.Die(err)
-	}
-	if err := cloudTemplateRestoreCmd.MarkFlagRequired("template"); err != nil {
 		lwCliInst.Die(err)
 	}
 }

--- a/cmd/defaultFlags.go
+++ b/cmd/defaultFlags.go
@@ -1,0 +1,43 @@
+/*
+Copyright © LiquidWeb
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var defaultFlagsCmd = &cobra.Command{
+	Use:   "default-flags",
+	Short: "Manage default flags",
+	Long: `Manage the configured default flags.
+
+If a default flag is set (such as for "zone") then any subcommand will use its
+value in place if omitted.
+
+For a full list of capabilities, please refer to the "Available Commands" section.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := cmd.Help(); err != nil {
+			lwCliInst.Die(err)
+		}
+		os.Exit(1)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(defaultFlagsCmd)
+}

--- a/cmd/defaultFlags.go
+++ b/cmd/defaultFlags.go
@@ -27,7 +27,8 @@ var defaultFlagsCmd = &cobra.Command{
 	Long: `Manage the configured default flags.
 
 If a default flag is set (such as for "zone") then any subcommand will use its
-value in place if omitted.
+value in place if omitted. Default flags are auth context aware. For details
+on auth contexts, see 'help auth'.
 
 For a full list of capabilities, please refer to the "Available Commands" section.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/defaultFlagsDelete.go
+++ b/cmd/defaultFlagsDelete.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2019 LiquidWeb
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
+)
+
+var defaultFlagsDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a default flag",
+	Long: `Delete a default flag.
+
+When a default flag is set (such as "zone") then any subcommand will use its
+value in place if omitted.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		flagName, _ := cmd.Flags().GetString("flag")
+
+		if err := defaults.Delete(flagName); err != nil {
+			lwCliInst.Die(err)
+		}
+
+		fmt.Printf("deleted default flag [%s]\n", flagName)
+	},
+}
+
+func init() {
+	defaultFlagsCmd.AddCommand(defaultFlagsDeleteCmd)
+	defaultFlagsDeleteCmd.Flags().String("flag", "", "name of the default flag to delete")
+	if err := defaultFlagsDeleteCmd.MarkFlagRequired("flag"); err != nil {
+		lwCliInst.Die(err)
+	}
+}

--- a/cmd/defaultFlagsDelete.go
+++ b/cmd/defaultFlagsDelete.go
@@ -25,11 +25,12 @@ import (
 
 var defaultFlagsDeleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Delete a default flag",
-	Long: `Delete a default flag.
+	Short: "Delete a flag",
+	Long: `Delete a flag for the current context.
 
 When a default flag is set (such as "zone") then any subcommand will use its
-value in place if omitted.`,
+value in place if omitted. Default flags are auth context aware. For details
+on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		flagName, _ := cmd.Flags().GetString("flag")
 
@@ -43,7 +44,7 @@ value in place if omitted.`,
 
 func init() {
 	defaultFlagsCmd.AddCommand(defaultFlagsDeleteCmd)
-	defaultFlagsDeleteCmd.Flags().String("flag", "", "name of the default flag to delete")
+	defaultFlagsDeleteCmd.Flags().String("flag", "", "name of the flag to delete")
 	if err := defaultFlagsDeleteCmd.MarkFlagRequired("flag"); err != nil {
 		lwCliInst.Die(err)
 	}

--- a/cmd/defaultFlagsGet.go
+++ b/cmd/defaultFlagsGet.go
@@ -1,0 +1,52 @@
+/*
+Copyright © 2019 LiquidWeb
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
+)
+
+var defaultFlagsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get details on a flag",
+	Long: `Get details on a flag.
+
+When a default flag is set (such as "zone") then any subcommand will use its
+value in place if omitted.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		flagName, _ := cmd.Flags().GetString("flag")
+
+		value, err := defaults.Get(flagName)
+		if err != nil {
+			lwCliInst.Die(err)
+		}
+
+		fmt.Printf("flag: %s\n", flagName)
+		fmt.Printf("\tvalue: %+v\n", value)
+	},
+}
+
+func init() {
+	defaultFlagsCmd.AddCommand(defaultFlagsGetCmd)
+	defaultFlagsGetCmd.Flags().String("flag", "", "name of the default flag")
+	if err := defaultFlagsGetCmd.MarkFlagRequired("flag"); err != nil {
+		lwCliInst.Die(err)
+	}
+}

--- a/cmd/defaultFlagsGet.go
+++ b/cmd/defaultFlagsGet.go
@@ -26,10 +26,11 @@ import (
 var defaultFlagsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get details on a flag",
-	Long: `Get details on a flag.
+	Long: `Get details on a flag in the current context.
 
 When a default flag is set (such as "zone") then any subcommand will use its
-value in place if omitted.`,
+value in place if omitted. Default flags are auth context aware. For details
+on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		flagName, _ := cmd.Flags().GetString("flag")
 
@@ -45,7 +46,7 @@ value in place if omitted.`,
 
 func init() {
 	defaultFlagsCmd.AddCommand(defaultFlagsGetCmd)
-	defaultFlagsGetCmd.Flags().String("flag", "", "name of the default flag")
+	defaultFlagsGetCmd.Flags().String("flag", "", "name of the flag")
 	if err := defaultFlagsGetCmd.MarkFlagRequired("flag"); err != nil {
 		lwCliInst.Die(err)
 	}

--- a/cmd/defaultFlagsList.go
+++ b/cmd/defaultFlagsList.go
@@ -1,0 +1,43 @@
+/*
+Copyright © 2019 LiquidWeb
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
+)
+
+var defaultFlagsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Display your set default flags",
+	Long: `Display your set default flags.
+
+If you've never created any default flags, check "default-flags add".`,
+	Run: func(cmd *cobra.Command, args []string) {
+		all, err := defaults.GetAll()
+		if err != nil {
+			lwCliInst.Die(err)
+		}
+		fmt.Print(all)
+	},
+}
+
+func init() {
+	defaultFlagsCmd.AddCommand(defaultFlagsListCmd)
+}

--- a/cmd/defaultFlagsList.go
+++ b/cmd/defaultFlagsList.go
@@ -28,7 +28,11 @@ var defaultFlagsListCmd = &cobra.Command{
 	Short: "Display your set default flags",
 	Long: `Display your set default flags.
 
-If you've never created any default flags, check "default-flags add".`,
+If you've never created any default flags, see 'help default-flags set'.
+
+When a default flag is set (such as "zone") then any subcommand will use its
+value in place if omitted. Default flags are auth context aware. For details
+on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		all, err := defaults.GetAll()
 		if err != nil {

--- a/cmd/defaultFlagsNagOff.go
+++ b/cmd/defaultFlagsNagOff.go
@@ -23,34 +23,23 @@ import (
 	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 )
 
-var defaultFlagsSetCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Set a flag",
-	Long: `Set a flag for the current context.
+var defaultFlagsNagOffCmd = &cobra.Command{
+	Use:   "nags-off",
+	Short: "Turn nags off",
+	Long: `Turn nags off for unset default flags.
 
 When a default flag is set (such as "zone") then any subcommand will use its
 value in place if omitted. Default flags are auth context aware. For details
 on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		flagName, _ := cmd.Flags().GetString("flag")
-		flagValue, _ := cmd.Flags().GetString("value")
-
-		if err := defaults.Set(flagName, flagValue); err != nil {
+		if err := defaults.NagsOff(); err != nil {
 			lwCliInst.Die(err)
 		}
 
-		fmt.Printf("flag [%s] set with value [%s]\n", flagName, flagValue)
+		fmt.Println("Nags turned off.")
 	},
 }
 
 func init() {
-	defaultFlagsCmd.AddCommand(defaultFlagsSetCmd)
-	defaultFlagsSetCmd.Flags().String("flag", "", "name of the flag to set")
-	defaultFlagsSetCmd.Flags().String("value", "", "value for the flag")
-	reqs := []string{"flag", "value"}
-	for _, req := range reqs {
-		if err := defaultFlagsSetCmd.MarkFlagRequired(req); err != nil {
-			lwCliInst.Die(err)
-		}
-	}
+	defaultFlagsCmd.AddCommand(defaultFlagsNagOffCmd)
 }

--- a/cmd/defaultFlagsNagOn.go
+++ b/cmd/defaultFlagsNagOn.go
@@ -23,34 +23,23 @@ import (
 	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 )
 
-var defaultFlagsSetCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Set a flag",
-	Long: `Set a flag for the current context.
+var defaultFlagsNagOnCmd = &cobra.Command{
+	Use:   "nags-on",
+	Short: "Turn nags on",
+	Long: `Turn nags on for unset default flags.
 
 When a default flag is set (such as "zone") then any subcommand will use its
 value in place if omitted. Default flags are auth context aware. For details
 on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		flagName, _ := cmd.Flags().GetString("flag")
-		flagValue, _ := cmd.Flags().GetString("value")
-
-		if err := defaults.Set(flagName, flagValue); err != nil {
+		if err := defaults.NagsOn(); err != nil {
 			lwCliInst.Die(err)
 		}
 
-		fmt.Printf("flag [%s] set with value [%s]\n", flagName, flagValue)
+		fmt.Println("Nags turned on.")
 	},
 }
 
 func init() {
-	defaultFlagsCmd.AddCommand(defaultFlagsSetCmd)
-	defaultFlagsSetCmd.Flags().String("flag", "", "name of the flag to set")
-	defaultFlagsSetCmd.Flags().String("value", "", "value for the flag")
-	reqs := []string{"flag", "value"}
-	for _, req := range reqs {
-		if err := defaultFlagsSetCmd.MarkFlagRequired(req); err != nil {
-			lwCliInst.Die(err)
-		}
-	}
+	defaultFlagsCmd.AddCommand(defaultFlagsNagOnCmd)
 }

--- a/cmd/defaultFlagsPermitted.go
+++ b/cmd/defaultFlagsPermitted.go
@@ -23,34 +23,28 @@ import (
 	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 )
 
-var defaultFlagsSetCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Set a flag",
-	Long: `Set a flag for the current context.
+var defaultFlagsPermittedCmd = &cobra.Command{
+	Use:   "permitted",
+	Short: "Display permitted default flags",
+	Long: `Display permitted default flags.
+
+If you've never created any default flags, see 'help default-flags set'.
 
 When a default flag is set (such as "zone") then any subcommand will use its
 value in place if omitted. Default flags are auth context aware. For details
 on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		flagName, _ := cmd.Flags().GetString("flag")
-		flagValue, _ := cmd.Flags().GetString("value")
-
-		if err := defaults.Set(flagName, flagValue); err != nil {
-			lwCliInst.Die(err)
+		permitted := defaults.GetPermitted()
+		fmt.Println("Permitted flags:")
+		for flag, v := range permitted {
+			if !v {
+				continue
+			}
+			fmt.Printf("  %s\n", flag)
 		}
-
-		fmt.Printf("flag [%s] set with value [%s]\n", flagName, flagValue)
 	},
 }
 
 func init() {
-	defaultFlagsCmd.AddCommand(defaultFlagsSetCmd)
-	defaultFlagsSetCmd.Flags().String("flag", "", "name of the flag to set")
-	defaultFlagsSetCmd.Flags().String("value", "", "value for the flag")
-	reqs := []string{"flag", "value"}
-	for _, req := range reqs {
-		if err := defaultFlagsSetCmd.MarkFlagRequired(req); err != nil {
-			lwCliInst.Die(err)
-		}
-	}
+	defaultFlagsCmd.AddCommand(defaultFlagsPermittedCmd)
 }

--- a/cmd/defaultFlagsPermitted.go
+++ b/cmd/defaultFlagsPermitted.go
@@ -36,10 +36,7 @@ on auth contexts, see 'help auth'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		permitted := defaults.GetPermitted()
 		fmt.Println("Permitted flags:")
-		for flag, v := range permitted {
-			if !v {
-				continue
-			}
+		for _, flag := range permitted {
 			fmt.Printf("  %s\n", flag)
 		}
 	},

--- a/cmd/defaultFlagsSet.go
+++ b/cmd/defaultFlagsSet.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2019 LiquidWeb
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
+)
+
+var defaultFlagsSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set a default flag",
+	Long: `Set a default flag.
+
+When a default flag is set (such as "zone") then any subcommand will use its
+value in place if omitted.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		flagName, _ := cmd.Flags().GetString("flag")
+		flagValue, _ := cmd.Flags().GetString("value")
+
+		if err := defaults.Set(flagName, flagValue); err != nil {
+			lwCliInst.Die(err)
+		}
+
+		fmt.Printf("default flag [%s] set with value [%s]\n", flagName, flagValue)
+	},
+}
+
+func init() {
+	defaultFlagsCmd.AddCommand(defaultFlagsSetCmd)
+	defaultFlagsSetCmd.Flags().String("flag", "", "name of the default flag to set")
+	defaultFlagsSetCmd.Flags().String("value", "", "value for the default flag")
+	reqs := []string{"flag", "value"}
+	for _, req := range reqs {
+		if err := defaultFlagsSetCmd.MarkFlagRequired(req); err != nil {
+			lwCliInst.Die(err)
+		}
+	}
+}

--- a/cmd/networkIpPoolCreate.go
+++ b/cmd/networkIpPoolCreate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
-	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/types/api"
 )
 
@@ -67,6 +66,6 @@ func init() {
 	networkIpPoolCreateCmd.Flags().StringSliceVar(&networkIpPoolCreateCmdAddIpsFlag, "add-ips", []string{},
 		"ips separated by ',' to add to created IP Pool")
 	networkIpPoolCreateCmd.Flags().Int64("new-ips", -1, "amount of IPs to assign to the created IP Pool")
-	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")),
+	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")),
 		"zone id to create the IP Pool in")
 }

--- a/cmd/networkIpPoolCreate.go
+++ b/cmd/networkIpPoolCreate.go
@@ -66,6 +66,6 @@ func init() {
 	networkIpPoolCreateCmd.Flags().StringSliceVar(&networkIpPoolCreateCmdAddIpsFlag, "add-ips", []string{},
 		"ips separated by ',' to add to created IP Pool")
 	networkIpPoolCreateCmd.Flags().Int64("new-ips", -1, "amount of IPs to assign to the created IP Pool")
-	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
+	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("network_ip-pool_create_zone", -1)),
 		"zone id to create the IP Pool in")
 }

--- a/cmd/networkIpPoolCreate.go
+++ b/cmd/networkIpPoolCreate.go
@@ -37,7 +37,7 @@ your account.`,
 		zoneFlag, _ := cmd.Flags().GetInt64("zone")
 		newIpsFlag, _ := cmd.Flags().GetInt64("new-ips")
 
-		if len(networkIpPoolCreateCmdAddIpsFlag) == 0 && newIpsFlag == -1 || zoneFlag == 0 {
+		if len(networkIpPoolCreateCmdAddIpsFlag) == 0 && newIpsFlag == -1 || zoneFlag == -1 {
 			lwCliInst.Die(fmt.Errorf("flags --new-ips --add-ips cannot both be empty. --zone cannot be empty"))
 		}
 
@@ -66,6 +66,6 @@ func init() {
 	networkIpPoolCreateCmd.Flags().StringSliceVar(&networkIpPoolCreateCmdAddIpsFlag, "add-ips", []string{},
 		"ips separated by ',' to add to created IP Pool")
 	networkIpPoolCreateCmd.Flags().Int64("new-ips", -1, "amount of IPs to assign to the created IP Pool")
-	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone")),
+	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaultFlag("zone", -1)),
 		"zone id to create the IP Pool in")
 }

--- a/cmd/networkIpPoolCreate.go
+++ b/cmd/networkIpPoolCreate.go
@@ -18,8 +18,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
+	"github.com/liquidweb/liquidweb-cli/flags/defaults"
 	"github.com/liquidweb/liquidweb-cli/types/api"
 )
 
@@ -36,11 +38,8 @@ your account.`,
 		zoneFlag, _ := cmd.Flags().GetInt64("zone")
 		newIpsFlag, _ := cmd.Flags().GetInt64("new-ips")
 
-		//fmt.Printf("networkIpPoolCreateCmdAddIpsFlag: %+v\n", networkIpPoolCreateCmdAddIpsFlag)
-		//fmt.Printf("%d %d\n", newIpsFlag, zoneFlag)
-
-		if len(networkIpPoolCreateCmdAddIpsFlag) == 0 && newIpsFlag == -1 {
-			lwCliInst.Die(fmt.Errorf("flags --new-ips --add-ips cannot both be empty"))
+		if len(networkIpPoolCreateCmdAddIpsFlag) == 0 && newIpsFlag == -1 || zoneFlag == 0 {
+			lwCliInst.Die(fmt.Errorf("flags --new-ips --add-ips cannot both be empty. --zone cannot be empty"))
 		}
 
 		apiArgs := map[string]interface{}{
@@ -68,9 +67,6 @@ func init() {
 	networkIpPoolCreateCmd.Flags().StringSliceVar(&networkIpPoolCreateCmdAddIpsFlag, "add-ips", []string{},
 		"ips separated by ',' to add to created IP Pool")
 	networkIpPoolCreateCmd.Flags().Int64("new-ips", -1, "amount of IPs to assign to the created IP Pool")
-	networkIpPoolCreateCmd.Flags().Int64("zone", -1, "zone id to create the IP Pool in")
-
-	if err := networkIpPoolCreateCmd.MarkFlagRequired("zone"); err != nil {
-		lwCliInst.Die(err)
-	}
+	networkIpPoolCreateCmd.Flags().Int64("zone", cast.ToInt64(defaults.GetOrNag("zone")),
+		"zone id to create the IP Pool in")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ import (
 )
 
 var cfgFile string
-var lwCliInst instance.Client
+var lwCliInst *instance.Client
 var useContext string
 
 var rootCmd = &cobra.Command{
@@ -70,17 +70,16 @@ func init() {
 
 func initConfig() {
 	vp := viper.New()
+
 	if cfgFile != "" {
 		// Use config file from the flag.
 		vp.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
+		// Search config in home directory with name ".liquidweb-cli" (without extension).
 		home, err := homedir.Dir()
 		if err != nil {
 			lwCliInst.Die(err)
 		}
-
-		// Search config in home directory with name ".liquidweb-cli" (without extension).
 		vp.AddConfigPath(home)
 		vp.SetConfigName(".liquidweb-cli")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,11 +101,14 @@ func osArgsForContext(re *regexp.Regexp) {
 	}
 }
 
-func defaultFlag(flag string) (value interface{}) {
+func defaultFlag(flag string, defaultValueList ...interface{}) (value interface{}) {
 	// calling config.InitConfig() here so default context gets set
 	_, _ = config.InitConfig()
 	setConfigArgs()
 	value = defaults.GetOrNag(flag)
+	if len(defaultValueList) > 0 && value == nil {
+		value = defaultValueList[0]
+	}
 	return
 }
 

--- a/config/core.go
+++ b/config/core.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"fmt"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+
+	"github.com/liquidweb/liquidweb-cli/instance"
+	"github.com/liquidweb/liquidweb-cli/utils"
+)
+
+var (
+	CurrentContext string
+	ConfigFileArg  string
+	UseContextArg  string
+)
+
+func InitConfig() (vp *viper.Viper, err error) {
+	vp = viper.New()
+
+	if ConfigFileArg != "" {
+		// Use config file from the flag.
+		vp.SetConfigFile(ConfigFileArg)
+	} else {
+		// Search config in home directory with name ".liquidweb-cli" (without extension).
+		var home string
+		home, err = homedir.Dir()
+		if err != nil {
+			return
+		}
+		vp.AddConfigPath(home)
+		vp.SetConfigName(".liquidweb-cli")
+	}
+
+	vp.AutomaticEnv()
+	if err := vp.ReadInConfig(); err != nil {
+		utils.PrintYellow("no config\n")
+	}
+
+	if UseContextArg != "" {
+		if err = instance.ValidateContext(UseContextArg, vp); err != nil {
+			err = fmt.Errorf("error using auth context: %s\n", err)
+			return
+		}
+		vp.Set("liquidweb.api.current_context", UseContextArg)
+	}
+
+	CurrentContext = vp.GetString("liquidweb.api.current_context")
+
+	return
+}

--- a/config/core.go
+++ b/config/core.go
@@ -34,8 +34,13 @@ func InitConfig() (vp *viper.Viper, err error) {
 	}
 
 	vp.AutomaticEnv()
-	if err := vp.ReadInConfig(); err != nil {
-		utils.PrintYellow("no config\n")
+	if err = vp.ReadInConfig(); err != nil {
+		if _, notFound := err.(viper.ConfigFileNotFoundError); notFound {
+			err = nil
+			return
+		}
+		utils.PrintYellow("error reading config: %s\n", err)
+		return
 	}
 
 	if UseContextArg != "" {

--- a/flags/defaults/constants.go
+++ b/flags/defaults/constants.go
@@ -1,4 +1,5 @@
 package defaults
 
+const NagsKey = "nags"
 const DefFlagsKey = "defaults"
 const DefaultFlagsFileKey = "liquidweb.flags.defaults.file"

--- a/flags/defaults/constants.go
+++ b/flags/defaults/constants.go
@@ -1,0 +1,4 @@
+package defaults
+
+const DefFlagsKey = "defaults"
+const DefaultFlagsFileKey = "liquidweb.flags.defaults.file"

--- a/flags/defaults/core.go
+++ b/flags/defaults/core.go
@@ -143,7 +143,7 @@ func permittedFlagOrError(flag string) (err error) {
 		return
 	}
 
-	if _, exists := permittedFlags[flag]; !exists {
+	if v, exists := permittedFlags[flag]; !exists || !v {
 		err = fmt.Errorf("%s %w", flag, ErrorForbiddenFlag)
 	}
 

--- a/flags/defaults/core.go
+++ b/flags/defaults/core.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
@@ -41,8 +42,16 @@ func NagsOn() (err error) {
 	return
 }
 
-func GetPermitted() (permitted map[string]bool) {
-	permitted = permittedFlags
+func GetPermitted() (permitted []string) {
+	permitted = make([]string, 0, len(permittedFlags))
+	for flag, val := range permittedFlags {
+		if !val {
+			continue
+		}
+		permitted = append(permitted, flag)
+	}
+	sort.Strings(permitted)
+
 	return
 }
 

--- a/flags/defaults/core.go
+++ b/flags/defaults/core.go
@@ -1,0 +1,182 @@
+package defaults
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+
+	"github.com/liquidweb/liquidweb-cli/utils"
+)
+
+func init() {
+	home, err := homedir.Dir()
+	if err != nil {
+		utils.PrintYellow("failed fetching homedir: %s\n", err)
+		return
+	}
+	viper.SetDefault("liquidweb.flags.defaults.file", fmt.Sprintf("%s/.liquidweb-cli-flag-defaults.yaml", home))
+}
+
+//var flagDefaultsFile = viper.GetString("liquidweb.flags.defaults.file")
+
+func GetOrNag(flag string) (value interface{}) {
+	var err error
+	value, err = Get(flag)
+	if err != nil {
+		if errors.Is(err, ErrorNotFound) {
+			utils.PrintTeal("No default for flag [%s] set. See 'help default-flags set' for details.\n", flag)
+		} else {
+			utils.PrintYellow("Unexpected error when fetching value for default flag [%s]: %s\n", flag, err)
+		}
+	}
+	return
+}
+
+func Get(flag string) (value interface{}, err error) {
+	if err = permittedFlagOrError(flag); err != nil {
+		return
+	}
+
+	var flags map[string]interface{}
+	flags, err = getFlagsMap()
+	if err != nil {
+		return
+	}
+
+	if v, exists := flags[flag]; exists {
+		value = v
+		return
+	}
+
+	err = fmt.Errorf("%s %w", flag, ErrorNotFound)
+	return
+}
+
+func GetAll() (all AllFlags, err error) {
+	all, err = getFlagsMap()
+
+	return
+}
+
+func Set(flag string, value interface{}) (err error) {
+	if err = permittedFlagOrError(flag); err != nil {
+		return
+	}
+
+	var (
+		vp    *viper.Viper
+		flags map[string]interface{}
+	)
+	vp, flags, err = getFlagsViperAndMap()
+	if err != nil {
+		return
+	}
+
+	flags[flag] = value
+	vp.Set(DefFlagsKey, flags)
+
+	if err = vp.WriteConfig(); err != nil {
+		err = fmt.Errorf("%w: %s", ErrorUnwritable, err)
+	}
+
+	return
+}
+
+func Delete(flag string) (err error) {
+	if err = permittedFlagOrError(flag); err != nil {
+		return
+	}
+
+	var (
+		vp    *viper.Viper
+		flags map[string]interface{}
+	)
+	vp, flags, err = getFlagsViperAndMap()
+	if err != nil {
+		return
+	}
+
+	delete(flags, flag)
+	vp.Set(DefFlagsKey, flags)
+	err = vp.WriteConfig()
+
+	return
+}
+
+func permittedFlagOrError(flag string) (err error) {
+	if flag == "" {
+		err = ErrorInvalidFlagName
+		return
+	}
+
+	if _, exists := permittedFlags[flag]; !exists {
+		err = fmt.Errorf("%s %w", flag, ErrorForbiddenFlag)
+	}
+
+	return
+}
+
+func getFlagsViperAndMap() (vp *viper.Viper, flags map[string]interface{}, err error) {
+	vp, err = getFlagsViper()
+	if err != nil {
+		return
+	}
+
+	flags, err = getFlagsMap(vp)
+
+	return
+}
+
+func getFlagsMap(vpL ...*viper.Viper) (flags map[string]interface{}, err error) {
+	var vp *viper.Viper
+	if len(vpL) == 0 {
+		if vp, err = getFlagsViper(); err != nil {
+			return
+		}
+	} else {
+		vp = vpL[0]
+	}
+
+	flags = vp.GetStringMap(DefFlagsKey)
+
+	return
+}
+
+func getFlagsViper() (vp *viper.Viper, err error) {
+	var file string
+	file, err = getFlagsFile()
+	if err != nil {
+		return
+	}
+
+	vp = viper.New()
+	vp.SetConfigFile(file)
+	if err = vp.ReadInConfig(); err != nil {
+		err = fmt.Errorf("%w: %s", ErrorUnreadable, err)
+		return
+	}
+
+	return
+}
+
+func getFlagsFile() (file string, err error) {
+	file = viper.GetString(DefaultFlagsFileKey)
+	if file == "" {
+		err = ErrorFileKeyMissing
+	}
+
+	if _, err = os.Stat(file); os.IsNotExist(err) {
+		err = nil
+		f, ferr := os.Create(file)
+		if ferr != nil {
+			err = ferr
+			return
+		}
+		err = f.Close()
+	}
+
+	return
+}

--- a/flags/defaults/errors.go
+++ b/flags/defaults/errors.go
@@ -1,0 +1,12 @@
+package defaults
+
+import (
+	"errors"
+)
+
+var ErrorForbiddenFlag = errors.New("is a forbidden default flag")
+var ErrorInvalidFlagName = errors.New("the given flag name is invalid")
+var ErrorFileKeyMissing = errors.New("flag defaults file key is missing")
+var ErrorUnwritable = errors.New("flag defaults cannot be written")
+var ErrorUnreadable = errors.New("flag defaults cannot be read")
+var ErrorNotFound = errors.New("flag default not found")

--- a/flags/defaults/types.go
+++ b/flags/defaults/types.go
@@ -25,7 +25,22 @@ func (self AllFlags) String() string {
 }
 
 var permittedFlags = map[string]bool{
-	"zone":      true,
-	"template":  true,
-	"config-id": true,
+	// cloud network vip create
+	"cloud_network_vip_create_zone": true,
+	// cloud private-parent create
+	"cloud_private-parent_create_config-id": true,
+	"cloud_private-parent_create_zone":      true,
+	// cloud server clone
+	"cloud_server_clone_config-id": true,
+	// cloud server create
+	"cloud_server_create_zone":      true,
+	"cloud_server_create_template":  true,
+	"cloud_server_create_config-id": true,
+	// cloud server resize
+	"cloud_server_resize_config-id": true,
+	// cloud template restore
+	"cloud_template_restore_template": true,
+
+	// network ip-pool create
+	"network_ip-pool_create_zone": true,
 }

--- a/flags/defaults/types.go
+++ b/flags/defaults/types.go
@@ -16,15 +16,15 @@ func (self AllFlags) String() string {
 		slice = append(slice, "Configured default flags:\n\n")
 
 		for flag, value := range self {
-			slice = append(slice, fmt.Sprintf("\tFlag: %s\n", flag))
-			slice = append(slice, fmt.Sprintf("\t\tValue: %+v\n", value))
+			slice = append(slice, fmt.Sprintf("  Flag: %s\n", flag))
+			slice = append(slice, fmt.Sprintf("    Value: %+v\n", value))
 		}
 	}
 
 	return strings.Join(slice[:], "")
 }
 
-var permittedFlags = map[string]interface{}{
+var permittedFlags = map[string]bool{
 	"zone":     true,
 	"template": true,
 }

--- a/flags/defaults/types.go
+++ b/flags/defaults/types.go
@@ -24,23 +24,52 @@ func (self AllFlags) String() string {
 	return strings.Join(slice[:], "")
 }
 
-var permittedFlags = map[string]bool{
+var permittedFlags = map[string]map[string]interface{}{
 	// cloud network vip create
-	"cloud_network_vip_create_zone": true,
+	"cloud_network_vip_create_zone": map[string]interface{}{
+		"enabled":   true,
+		"validator": "PositiveInt64",
+	},
 	// cloud private-parent create
-	"cloud_private-parent_create_config-id": true,
-	"cloud_private-parent_create_zone":      true,
+	"cloud_private-parent_create_config-id": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
+	"cloud_private-parent_create_zone": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
 	// cloud server clone
-	"cloud_server_clone_config-id": true,
+	"cloud_server_clone_config-id": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
 	// cloud server create
-	"cloud_server_create_zone":      true,
-	"cloud_server_create_template":  true,
-	"cloud_server_create_config-id": true,
+	"cloud_server_create_zone": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
+	"cloud_server_create_template": map[string]interface{}{
+		"enabled": true,
+		"type":    "NonEmptyString",
+	},
+	"cloud_server_create_config-id": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
 	// cloud server resize
-	"cloud_server_resize_config-id": true,
+	"cloud_server_resize_config-id": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
 	// cloud template restore
-	"cloud_template_restore_template": true,
-
+	"cloud_template_restore_template": map[string]interface{}{
+		"enabled": true,
+		"type":    "NonEmptyString",
+	},
 	// network ip-pool create
-	"network_ip-pool_create_zone": true,
+	"network_ip-pool_create_zone": map[string]interface{}{
+		"enabled": true,
+		"type":    "PositiveInt64",
+	},
 }

--- a/flags/defaults/types.go
+++ b/flags/defaults/types.go
@@ -25,6 +25,7 @@ func (self AllFlags) String() string {
 }
 
 var permittedFlags = map[string]bool{
-	"zone":     true,
-	"template": true,
+	"zone":      true,
+	"template":  true,
+	"config-id": true,
 }

--- a/flags/defaults/types.go
+++ b/flags/defaults/types.go
@@ -1,0 +1,30 @@
+package defaults
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AllFlags map[string]interface{}
+
+func (self AllFlags) String() string {
+	var slice []string
+
+	if len(self) == 0 {
+		slice = append(slice, "No configured default flags. Set some with 'default-flags set'.\n")
+	} else {
+		slice = append(slice, "Configured default flags:\n\n")
+
+		for flag, value := range self {
+			slice = append(slice, fmt.Sprintf("\tFlag: %s\n", flag))
+			slice = append(slice, fmt.Sprintf("\t\tValue: %+v\n", value))
+		}
+	}
+
+	return strings.Join(slice[:], "")
+}
+
+var permittedFlags = map[string]interface{}{
+	"zone":     true,
+	"template": true,
+}

--- a/instance/cloudServerCreate.go
+++ b/instance/cloudServerCreate.go
@@ -98,9 +98,6 @@ func (ci *Client) CloudServerCreate(params *CloudServerCreateParams) (string, er
 
 	// sanity check flags
 	if params.PrivateParent != "" {
-		if params.ConfigId > 0 {
-			return "", fmt.Errorf("--config-id must be 0 or omitted when specifying --private-parent")
-		}
 		// create on a private parent. diskspace, memory, vcpu are required.
 		if params.Memory == -1 {
 			return "", fmt.Errorf("--memory is required when specifying --private-parent")

--- a/instance/cloudTemplateRestore.go
+++ b/instance/cloudTemplateRestore.go
@@ -16,6 +16,8 @@ limitations under the License.
 package instance
 
 import (
+	"errors"
+
 	"github.com/liquidweb/liquidweb-cli/types/api"
 	"github.com/liquidweb/liquidweb-cli/validate"
 )
@@ -31,6 +33,10 @@ func (ci *Client) CloudTemplateRestore(params *CloudTemplateRestoreParams) (stri
 	}
 	if err := validate.Validate(validateFields); err != nil {
 		return "", err
+	}
+
+	if params.Template == "" {
+		return "", errors.New("template cannot be blank")
 	}
 
 	apiArgs := map[string]interface{}{"template": params.Template, "uniq_id": params.UniqId}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -32,16 +32,15 @@ import (
 	"github.com/liquidweb/liquidweb-cli/utils"
 )
 
-func New(viper *viper.Viper) (Client, error) {
-
+func New(viper *viper.Viper) (*Client, error) {
 	lwCliApiClient, err := lwCliInstApi.New(viper)
 	if err != nil {
-		return Client{}, fmt.Errorf(
+		return &Client{}, fmt.Errorf(
 			"Failed creating an lwApi client. Error was:\n%s\nPlease check your liquidweb-cli config file for errors or ommissions\n",
 			err)
 	}
 
-	client := Client{
+	client := &Client{
 		LwCliApiClient: lwCliApiClient,
 		Viper:          viper,
 	}


### PR DESCRIPTION
Introduces the concept of default flags from (https://github.com/liquidweb/liquidweb-cli/issues/23).

```
ssullivan@data ~/golang/src/github.com/liquidweb/liquidweb-cli $ lw help default-flags 
No default value for flag [template] set. See 'help default-flags set' for details.
TIP: You can silence undefined default flag notices with 'default-flags nags-off'
Manage the configured default flags.

If a default flag is set (such as for "zone") then any subcommand will use its
value in place if omitted. Default flags are auth context aware. For details
on auth contexts, see 'help auth'.

For a full list of capabilities, please refer to the "Available Commands" section.

Usage:
  lw default-flags [flags]
  lw default-flags [command]

Available Commands:
  delete      Delete a flag
  get         Get details on a flag
  list        Display your set default flags
  nags-off    Turn nags off
  nags-on     Turn nags on
  permitted   Display permitted default flags
  set         Set a flag

Flags:
  -h, --help   help for default-flags

Global Flags:
      --config string        config file (default is $HOME/.liquidweb-cli.yaml)
      --use-context string   forces current context, without persisting the context change

Use "lw default-flags [command] --help" for more information about a command.
ssullivan@data ~/golang/src/github.com/liquidweb/liquidweb-cli $ 
```
To start out, I've added support for `zone` and `template` flag default values.. and wired them in where appropriate. Following this system, we can now easily add any future default flags we wish.