### PR TITLE
Add cloud server reboot to plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,7 @@ A plan is a pre-defined yaml with optional template variables that can be used t
 repeate specific tasks.  Fields in the yaml file match the params you would send
 to the command.
 
-Current commands supported in a `plan` file:
-
-- cloud server create
-- cloud server resize
-- cloud template restore
-- ssh
+For current commands supported via plans, take a look in the `examples/plans` directory of this repo.
 
 Example:
 

--- a/examples/plans/cloud.server.reboot.yaml
+++ b/examples/plans/cloud.server.reboot.yaml
@@ -1,0 +1,8 @@
+---
+cloud:
+  server:
+    reboot:
+      - uniq-id: "{{- .Var.uniq_id -}}"
+        force: false
+      - uniq-id: "{{- .Var.uniq_id2 -}}"
+        force: false

--- a/instance/cloudServerReboot.go
+++ b/instance/cloudServerReboot.go
@@ -1,0 +1,70 @@
+/*
+Copyright © LiquidWeb
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package instance
+
+import (
+	"fmt"
+
+	"github.com/liquidweb/liquidweb-cli/types/api"
+	"github.com/liquidweb/liquidweb-cli/validate"
+)
+
+type CloudServerRebootParams struct {
+	UniqId string `yaml:"uniq-id"`
+	Force  bool   `yaml:"force"`
+}
+
+func (self *CloudServerRebootParams) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// define defaults
+	type rawType CloudServerRebootParams
+	raw := rawType{} // Put your defaults here
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	*self = CloudServerRebootParams(raw)
+
+	return nil
+}
+
+func (self *Client) CloudServerReboot(params *CloudServerRebootParams) (result string, err error) {
+
+	validateFields := map[interface{}]interface{}{
+		params.UniqId: "UniqId",
+	}
+
+	if err = validate.Validate(validateFields); err != nil {
+		return
+	}
+
+	force := 0
+	if params.Force {
+		force = 1
+	}
+
+	rebootArgs := map[string]interface{}{
+		"uniq_id": params.UniqId,
+		"force":   force,
+	}
+
+	var resp apiTypes.CloudServerRebootResponse
+	if err = self.CallLwApiInto("bleed/storm/server/reboot", rebootArgs, &resp); err != nil {
+		return
+	}
+
+	result = fmt.Sprintf("Rebooted: %s\n", resp.Rebooted)
+
+	return
+}

--- a/instance/plan.go
+++ b/instance/plan.go
@@ -33,6 +33,7 @@ type PlanCloud struct {
 type PlanCloudServer struct {
 	Create []CloudServerCreateParams
 	Resize []CloudServerResizeParams
+	Reboot []CloudServerRebootParams
 }
 
 type PlanCloudTemplate struct {
@@ -116,6 +117,13 @@ func (ci *Client) processPlanCloudServer(server *PlanCloudServer) error {
 			}
 		}
 	}
+	if server.Reboot != nil {
+		for _, r := range server.Reboot {
+			if err := ci.processPlanCloudServerReboot(&r); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }
@@ -136,6 +144,18 @@ func (ci *Client) processPlanCloudServerCreate(params *CloudServerCreateParams) 
 func (ci *Client) processPlanCloudServerResize(params *CloudServerResizeParams) error {
 
 	result, err := ci.CloudServerResize(params)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(result)
+
+	return nil
+}
+
+func (ci *Client) processPlanCloudServerReboot(params *CloudServerRebootParams) error {
+
+	result, err := ci.CloudServerReboot(params)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
adds `cloud server reboot` to plans and makes the cmd flag support passing multiple uniq-ids.

```shell
ssullivan@data ~ $ lw cloud server reboot --uniq-id Y7WB19,KYC8SM
Rebooted: Y7WB19
Rebooted: KYC8SM
ssullivan@data ~ $ lw cloud server status --uniq-id Y7WB19,KYC8SM
UniqId: Y7WB19
        domain: y8s8.k7uesbx5as.io
        status: Rebooting
        detailed status: Shutting down server
        running: [{CurrentStep:8 DetailedStatus:Shutting down server Name:Clean Reboot Status:Rebooting}]
        progress: 0
UniqId: KYC8SM
        domain: xc4h.n4e097cvma.io
        status: Rebooting
        detailed status: Shutting down server
        running: [{CurrentStep:8 DetailedStatus:Shutting down server Name:Clean Reboot Status:Rebooting}]
        progress: 0
ssullivan@data ~ $ 
```

Also works via the plan example:

```shell
ssullivan@data ~ $ lw plan --file examples/plans/cloud.server.reboot.yaml --var uniq_id=Y7WB19 --var uniq_id2=KYC8SM
Rebooted: Y7WB19
Rebooted: KYC8SM
ssullivan@data ~ $
```